### PR TITLE
Make mraa_gpio_isr threading safe

### DIFF
--- a/src/gpio/gpio.c
+++ b/src/gpio/gpio.c
@@ -107,7 +107,7 @@ mraa_gpio_init_raw(int pin)
         int export = open(SYSFS_CLASS_GPIO "/export", O_WRONLY);
         if (export == -1) {
             syslog(LOG_ERR, "gpio: Failed to open export for writing");
-	    free(dev);
+            free(dev);
             return NULL;
         }
         length = snprintf(bu, sizeof(bu), "%d", dev->pin);
@@ -300,9 +300,10 @@ mraa_gpio_isr_exit(mraa_gpio_context dev)
     // stop isr being useful
     ret = mraa_gpio_edge_mode(dev, MRAA_GPIO_EDGE_NONE);
 
-    if ((dev->thread_id != 0) &&
-        (pthread_cancel(dev->thread_id) != 0)) {
-        ret = MRAA_ERROR_INVALID_HANDLE;
+    if ((dev->thread_id != 0)) {
+        if ((pthread_cancel(dev->thread_id) != 0) || (pthread_join(dev->thread_id, NULL) != 0)) {
+            ret = MRAA_ERROR_INVALID_HANDLE;
+        }
     }
 
     // close the filehandle in case it's still open
@@ -451,7 +452,7 @@ mraa_gpio_read(mraa_gpio_context dev)
     char bu[2];
     if (read(dev->value_fp, bu, 2*sizeof(char)) != 2) {
         syslog(LOG_ERR, "gpio: Failed to read a sensible value from sysfs");
-	return -1;
+        return -1;
     }
     lseek(dev->value_fp, 0, SEEK_SET);
 


### PR DESCRIPTION
There is no safe way to use dynamically allocated resources as args for the isr callback in mraa_gpio_isr. Since you don't know when the interrupt handling thread has terminated, you can not know when to safely deallocate the resource, your isr callback function might still be using.

I tried to explain this here: https://software.intel.com/en-us/forums/topic/534435#comment-1802969

My suggestion would be to pthread_join the thread in mraa_gpio_isr_exit. I could not test this code. I even could not figure out how to compile using the cross compiler on my Mac. So please just take this as a suggestion.
