### PR TITLE
- Proper version requires for nodejs

### DIFF
--- a/src/javascript/package.json.cmake
+++ b/src/javascript/package.json.cmake
@@ -5,7 +5,7 @@
   "homepage": "http://github.com/intel-iot-devkit/mraa",
   "main" : "./mraa.node",
   "engines": {
-    "node": ">= 1.0.x"
+    "node": ">= 0.10.x"
   },
   "bugs": {
     "url" : "http://github.com/intel-iot-devkit/mraa/issues"


### PR DESCRIPTION
This alows to check against all current 0.10 node branches.
