### PR TITLE
Python app errors after 510 AIO calls

### DIFF
--- a/src/aio/aio.c
+++ b/src/aio/aio.c
@@ -162,8 +162,11 @@ mraa_aio_read(mraa_aio_context dev)
 mraa_result_t
 mraa_aio_close(mraa_aio_context dev)
 {
-    if (NULL != dev)
+    if (NULL != dev) {
+        if (dev->adc_in_fp != -1) 
+            close(dev->adc_in_fp);
         free(dev);
+    }    
 
     return(MRAA_SUCCESS);
 }


### PR DESCRIPTION
As per the thread:
https://communities.intel.com/thread/57797
Simple Python app stops working after 510 calls to AIO...

Problem not closing file handle when you destroy the MRAA object
