### PR TITLE
mraa.c: Fixed potential segfault on free()-in NULL in mraa_deinit()

### DIFF
--- a/src/mraa.c
+++ b/src/mraa.c
@@ -118,8 +118,12 @@ mraa_init()
 void
 mraa_deinit()
 {
-    free(plat->pins);
-    free(plat);
+    if (plat != NULL) {
+        if (plat->pins != NULL) {
+            free(plat->pins);
+        }
+        free(plat);
+    }
     closelog();
 }
 


### PR DESCRIPTION
Currently `mraa_deinit()` does `free()` on `plat->pins` and `plat` itself unconditionally.

That leads to a segfault if deinit is called without checking init's return code or when init is run as CTOR and no additional checks performed by the library user before deiniting (as e.g. it's done in https://github.com/intel-iot-devkit/mraa/blob/master/examples/hellomraa.c).

I propose adding a basic "not NULL" check before freeing, which would increase robustness of the library.
