### PR TITLE
Add a function to get a pin number from mraa_gpio_context

### DIFF
--- a/api/mraa/gpio.h
+++ b/api/mraa/gpio.h
@@ -192,6 +192,14 @@ mraa_result_t mraa_gpio_owner(mraa_gpio_context dev, mraa_boolean_t owner);
  */
 mraa_result_t mraa_gpio_use_mmaped(mraa_gpio_context dev, mraa_boolean_t mmap);
 
+/**
+ * Get a pin number of the gpio
+ *
+ * @param dev The Gpio context
+ * @return Pin number
+ */
+int mraa_gpio_get_pin(mraa_gpio_context dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/api/mraa/gpio.hpp
+++ b/api/mraa/gpio.hpp
@@ -183,6 +183,14 @@ class Gpio {
         mraa_result_t useMmap(bool enable) {
             return mraa_gpio_use_mmaped(m_gpio, (mraa_boolean_t) enable);
         }
+        /**
+         * Get pin number of Gpio
+         *
+         * @return Pin number
+         */
+        int getPin() {
+            return mraa_gpio_get_pin(m_gpio);
+        }
     private:
         mraa_gpio_context m_gpio;
 };

--- a/src/gpio/gpio.c
+++ b/src/gpio/gpio.c
@@ -573,3 +573,9 @@ mraa_gpio_use_mmaped(mraa_gpio_context dev, mraa_boolean_t mmap_en)
     syslog(LOG_ERR, "gpio: mmap not implemented on this platform");
     return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
 }
+
+int
+mraa_gpio_get_pin(mraa_gpio_context dev)
+{
+    return (int) dev->phy_pin;
+}


### PR DESCRIPTION
I add a function named **mraa_gpio_get_pin** .
This function is useful to restore a physical pin number in callback function.

For example,

```
void interrupt_in(void *arg)
{
  mraa_gpio_context dev = (mraa_gpio_context)arg;
  printf("Pushed %d", mraa_gpio_get_pin(dev));
}

int main(int argc, char *argv[])
{
  mraa_gpio_context in0 = mraa_gpio_init(14);
  mraa_gpio_dir(in0, MRAA_GPIO_IN);
  mraa_gpio_mode(in0, MRAA_GPIO_PULLUP);
  mraa_gpio_isr(in, MRAA_GPIO_EDGE_FALLING, interrupt_in, (void *)in0);

  mraa_gpio_context in1 = mraa_gpio_init(15);
  mraa_gpio_dir(in1, MRAA_GPIO_IN);
  mraa_gpio_mode(in1, MRAA_GPIO_PULLUP);
  mraa_gpio_isr(in, MRAA_GPIO_EDGE_FALLING, interrupt_in, (void *)in1);

  sleep(30);

  return 0;
}
```

Signed-off-by: Kenta Yonekura yoneken@ieee.org
