### PR TITLE
mraa.c: fix FTBFS on printf by adding format

### DIFF
--- a/src/mraa.c
+++ b/src/mraa.c
@@ -79,8 +79,8 @@ mraa_init()
         char *err_msg = "mraa: FATAL error, "
                         "libmraa program must be run as root (EUID 0), "
                         "cannot proceed\n";
-        syslog(LOG_ERR, err_msg);
-        fprintf(stderr, err_msg);
+        syslog(LOG_ERR, "%s", err_msg);
+        fprintf(stderr, "%s", err_msg);
         return MRAA_ERROR_PLATFORM_NOT_INITIALISED;
     }
 


### PR DESCRIPTION
gcc-4.8.2 fails to build from source and complains :

  error: format not a string literal and no format arguments

Change-Id: Ie6c5b1bdaed4c45e4958bb74c067ab95fb83f8f5
Signed-off-by: Philippe Coval <philippe.coval@open.eurogiciel.org>