### PR TITLE
gpio: mraa_gpio_dir allow output to set val

### DIFF
--- a/api/mraa/gpio.h
+++ b/api/mraa/gpio.h
@@ -70,7 +70,9 @@ typedef enum {
  */
 typedef enum {
     MRAA_GPIO_OUT    = 0, /**< Output. A Mode can also be set */
-    MRAA_GPIO_IN     = 1  /**< Input */
+    MRAA_GPIO_IN     = 1,  /**< Input */
+    MRAA_GPIO_OUT_HIGH = 2, /**< Output. Init High */
+    MRAA_GPIO_OUT_LOW = 3, /**< Output. Init Low */
 } gpio_dir_t;
 
 /**

--- a/api/mraa/gpio.hpp
+++ b/api/mraa/gpio.hpp
@@ -45,8 +45,10 @@ typedef enum {
  * Gpio Direction options
  */
 typedef enum {
-    DIR_OUT = 0, /**< Output. A Mode can also be set */
-    DIR_IN  = 1  /**< Input */
+    DIR_OUT      = 0, /**< Output. A Mode can also be set */
+    DIR_IN       = 1,  /**< Input */
+    DIR_OUT_HIGH = 2, /**< Output. Init High */
+    DIR_OUT_LOW  = 3, /**< Output. Init Low */
 } Dir;
 
 /**

--- a/src/gpio/gpio.c
+++ b/src/gpio/gpio.c
@@ -426,6 +426,13 @@ mraa_gpio_dir(mraa_gpio_context dev, gpio_dir_t dir)
         case MRAA_GPIO_IN:
             length = snprintf(bu, sizeof(bu), "in");
             break;
+        case MRAA_GPIO_OUT_HIGH:
+            length = snprintf(bu, sizeof(bu), "high");
+            break;
+        case MRAA_GPIO_OUT_LOW:
+            length = snprintf(bu, sizeof(bu), "low");
+            break;
+        
         default:
             close(direction);
             return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;


### PR DESCRIPTION
There is an issue that when you take an IO pin that has an external PU
resistor and switch it from INPUT to OUTPUT the state of the pin will go
down before you can set it back high.

Signed-off-by: Kurt Eckhardt <kurte@rockisland.com>