### PR TITLE
mraa: we now log version and user ID into syslog upon init

### DIFF
--- a/src/mraa.c
+++ b/src/mraa.c
@@ -70,8 +70,9 @@ mraa_init()
 #endif
 
     openlog("libmraa", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_LOCAL1);
-    syslog(LOG_DEBUG,
-           "libmraa initialised by user '%s' with EUID %d",
+    syslog(LOG_NOTICE,
+           "libmraa version %s initialised by user '%s' with EUID %d",
+           mraa_get_version(),
            (proc_user != NULL) ? proc_user->pw_name : "<unknown>",
            proc_euid);
 


### PR DESCRIPTION
How about such a solution to #98.

If we anyway want to log something (version), then let's reuse the existing DEBUG-level message, convert it to NOTICE and add version there.

It looks like that in the log:
```
Jan 25 14:36:33 edison-sd libmraa[493]: libmraa version v0.5.4-100-g6c73a8a initialised by user 'root' with EUID 0
```