### PR TITLE
aio.c: added normalized read returning a float in a 0.0-1.0 range

### DIFF
--- a/api/mraa/aio.h
+++ b/api/mraa/aio.h
@@ -68,6 +68,14 @@ mraa_aio_context mraa_aio_init(unsigned int pin);
 unsigned int mraa_aio_read(mraa_aio_context dev);
 
 /**
+ * Read the input voltage and return it as a normalized float (0.0f-1.0f).
+ *
+ * @param dev The AIO context
+ * @returns The current input voltage as a normalized float (0.0f-1.0f)
+ */
+float mraa_aio_read_normalized(mraa_aio_context dev);
+
+/**
  * Close the analog input context, this will free the memory for the context
  *
  * @param dev The AIO context

--- a/api/mraa/aio.hpp
+++ b/api/mraa/aio.hpp
@@ -66,6 +66,14 @@ class Aio {
             return mraa_aio_read(m_aio);
         }
         /**
+         * Read a value from the AIO pin and return it as a normalized float.
+         *
+         * @returns The current input voltage as a normalized float (0.0f-1.0f)
+         */
+        float readNormalized() {
+            return mraa_aio_read_normalized(m_aio);
+        }
+        /**
          * Set the bit value which mraa will shift the raw reading
          * from the ADC to. I.e. 10bits
          * @param bits the bits the return from read should be i.e 10

--- a/src/aio/aio.c
+++ b/src/aio/aio.c
@@ -159,6 +159,23 @@ mraa_aio_read(mraa_aio_context dev)
     return analog_value;
 }
 
+float
+mraa_aio_read_normalized(mraa_aio_context dev)
+{
+    if(dev == NULL) {
+        syslog(LOG_ERR, "aio: Device not valid");
+        return 0.0;
+    }
+
+    float analog_value_float;
+    float max_analog_value = (1 << dev->value_bit) - 1;
+    unsigned int analog_value_int = mraa_aio_read(dev);
+
+    analog_value_float = analog_value_int / max_analog_value;
+
+    return analog_value_float;
+}
+
 mraa_result_t
 mraa_aio_close(mraa_aio_context dev)
 {


### PR DESCRIPTION
Here is my take at #32 as far as I understood it.

@arfoll, @tingleby, I'd be grateful for comments on the code itself as well as if I got the request correctly at all :smiley:

Feel free to assign this one to me, I'll drive it to closure even if this first attempt is not really what we want to have here.

Tested with C, JS and Python AIO examples, works as intended, e.g. in JS it looked like:
```
<cut>
MRAA Version: v0.5.4-105-gbaa1a0a
analogvalue is: 822
analogValueFloat is: 0.80352
MRAA Version: v0.5.4-105-gbaa1a0a
analogvalue is: 996
analogValueFloat is: 0.97067
MRAA Version: v0.5.4-105-gbaa1a0a
analogvalue is: 1023
analogValueFloat is: 1.00000
<cut>
```