### PR TITLE
examples/aio: Added examples for mraa_aio_read_float()/readFloat()

### DIFF
--- a/examples/analogin_a0.c
+++ b/examples/analogin_a0.c
@@ -30,6 +30,7 @@ int main ()
 {
     mraa_aio_context adc_a0;
     uint16_t adc_value = 0;
+    float adc_value_float = 0.0;
 
     adc_a0 = mraa_aio_init(0);
     if (adc_a0 == NULL) {
@@ -38,7 +39,9 @@ int main ()
 
     for(;;) {
         adc_value = mraa_aio_read(adc_a0);
+        adc_value_float = mraa_aio_read_float(adc_a0);
         fprintf(stdout, "ADC A0 read %X - %d\n", adc_value, adc_value);
+        fprintf(stdout, "ADC A0 read float - %.5f\n", adc_value_float);
     }
 
     mraa_aio_close(adc_a0);

--- a/examples/c++/AioA0.cpp
+++ b/examples/c++/AioA0.cpp
@@ -28,6 +28,7 @@
 int main ()
 {
     uint16_t adc_value;
+    float adc_value_float;
     mraa::Aio* a0;
 
     a0 = new mraa::Aio(0);
@@ -37,7 +38,9 @@ int main ()
 
     for(;;) {
         adc_value = a0->read();
+        adc_value_float = a0->readFloat();
         fprintf(stdout, "ADC A0 read %X - %d\n", adc_value, adc_value);
+        fprintf(stdout, "ADC A0 read float - %.5f\n", adc_value_float);
     }
 
     return MRAA_SUCCESS;

--- a/examples/javascript/AioA0.js
+++ b/examples/javascript/AioA0.js
@@ -27,4 +27,6 @@ console.log('MRAA Version: ' + m.getVersion()); //write the mraa version to the 
 
 var analogPin0 = new m.Aio(0); //setup access analog inpuput pin 0
 var analogValue = analogPin0.read(); //read the value of the analog pin
+var analogValueFloat = analogPin0.readFloat(); //read the pin value as a float
 console.log(analogValue); //write the value of the analog pin to the console
+console.log(analogValueFloat.toFixed(5)); //write the value in the float format

--- a/examples/python/aio.py
+++ b/examples/python/aio.py
@@ -29,5 +29,6 @@ print (mraa.getVersion())
 try:
     x = mraa.Aio(0)
     print (x.read())
+    print ("%.5f" % x.readFloat())
 except:
     print ("Are you sure you have an ADC?")


### PR DESCRIPTION
Here's a patch for AIO examples updating them to use a new function added by cd6701d604