### PR TITLE
Add options for nodejs include directory

### DIFF
--- a/src/javascript/CMakeLists.txt
+++ b/src/javascript/CMakeLists.txt
@@ -1,4 +1,5 @@
-find_path (NODE_ROOT_DIR "node/node.h")
+find_path (NODE_ROOT_DIR "node/node.h" "src/node.h"
+  PATHS /usr/include/nodejs /usr/local/include/nodejs)
 
 set (NODE_INCLUDE_DIRS
   ${NODE_ROOT_DIR}/src


### PR DESCRIPTION
As there is a few options of nodejs include directory, we should modify the CMakeLists.txt.

In ubilinux (Debian), node.h is located at /usr/include/nodejs/src/node.h by aptitude.

Signed-off-by: Kenta Yonekura <yoneken@ieee.org>