### PR TITLE
SPI fixes for Beaglebone Black, New Example for SPI

### DIFF
--- a/api/mraa/spi.h
+++ b/api/mraa/spi.h
@@ -104,6 +104,14 @@ mraa_result_t mraa_spi_frequency(mraa_spi_context dev, int hz);
  */
 uint8_t mraa_spi_write(mraa_spi_context dev, uint8_t data);
 
+/** Write Two Bytes to the SPI device.
+*
+* @param dev The Spi context
+* @param data Data to send
+* @return Data received on the miso line
+*/
+uint16_t mraa_spi_write_uint16(mraa_spi_context dev, uint16_t data);
+
 /** Write Buffer of bytes to the SPI device. The pointer return has to be
  * free'd by the caller. It will return a NULL pointer in cases of error.
  *
@@ -113,6 +121,16 @@ uint8_t mraa_spi_write(mraa_spi_context dev, uint8_t data);
  * @return Data received on the miso line, same length as passed in
  */
 uint8_t* mraa_spi_write_buf(mraa_spi_context dev, uint8_t* data, int length);
+
+/** Write Buffer of uint16 to the SPI device. The pointer return has to be
+* free'd by the caller. It will return a NULL pointer in cases of error.
+*
+* @param dev The Spi context
+* @param data to send
+* @param length elements (in bytes) within buffer, Max 4096
+* @return Data received on the miso line, same length as passed in
+*/
+uint16_t* mraa_spi_write_buf_uint16(mraa_spi_context dev, uint16_t* data, int length);
 
 /** Transfer Buffer of bytes to the SPI device. Both send and recv buffers
  * are passed in
@@ -124,6 +142,17 @@ uint8_t* mraa_spi_write_buf(mraa_spi_context dev, uint8_t* data, int length);
  * @return Result of operation
  */
 mraa_result_t mraa_spi_transfer_buf(mraa_spi_context dev, uint8_t* data, uint8_t* rxbuf, int length);
+
+/** Transfer Buffer of uint16 to the SPI device. Both send and recv buffers
+* are passed in
+*
+* @param dev The Spi context
+* @param data to send
+* @param rxbuf buffer to recv data back, may be NULL
+* @param length elements (in bytes) within buffer, Max 4096
+* @return Result of operation
+*/
+mraa_result_t mraa_spi_transfer_buf_uint16(mraa_spi_context dev, uint16_t* data, uint16_t* rxbuf, int length);
 
 /**
  * Change the SPI lsb mode

--- a/api/mraa/spi.h
+++ b/api/mraa/spi.h
@@ -110,7 +110,7 @@ uint8_t mraa_spi_write(mraa_spi_context dev, uint8_t data);
 * @param data Data to send
 * @return Data received on the miso line
 */
-uint16_t mraa_spi_write_uint16(mraa_spi_context dev, uint16_t data);
+uint16_t mraa_spi_write_word(mraa_spi_context dev, uint16_t data);
 
 /** Write Buffer of bytes to the SPI device. The pointer return has to be
  * free'd by the caller. It will return a NULL pointer in cases of error.
@@ -130,7 +130,7 @@ uint8_t* mraa_spi_write_buf(mraa_spi_context dev, uint8_t* data, int length);
 * @param length elements (in bytes) within buffer, Max 4096
 * @return Data received on the miso line, same length as passed in
 */
-uint16_t* mraa_spi_write_buf_uint16(mraa_spi_context dev, uint16_t* data, int length);
+uint16_t* mraa_spi_write_buf_word(mraa_spi_context dev, uint16_t* data, int length);
 
 /** Transfer Buffer of bytes to the SPI device. Both send and recv buffers
  * are passed in
@@ -152,7 +152,7 @@ mraa_result_t mraa_spi_transfer_buf(mraa_spi_context dev, uint8_t* data, uint8_t
 * @param length elements (in bytes) within buffer, Max 4096
 * @return Result of operation
 */
-mraa_result_t mraa_spi_transfer_buf_uint16(mraa_spi_context dev, uint16_t* data, uint16_t* rxbuf, int length);
+mraa_result_t mraa_spi_transfer_buf_word(mraa_spi_context dev, uint16_t* data, uint16_t* rxbuf, int length);
 
 /**
  * Change the SPI lsb mode

--- a/api/mraa/spi.hpp
+++ b/api/mraa/spi.hpp
@@ -100,9 +100,19 @@ class Spi {
         }
 
         /**
+         * Write single byte to the SPI device
+         *
+         * @param data the byte to send
+         * @return data received on the miso line
+         */
+        uint16_t write_uint16(uint16_t data) {
+            return mraa_spi_write_uint16(m_spi, (uint16_t) data);
+        }
+
+        /**
          * Write buffer of bytes to SPI device The pointer return has to be
-	 * free'd by the caller. It will return a NULL pointer in cases of
-	 * error
+	     * free'd by the caller. It will return a NULL pointer in cases of
+	     * error
          *
          * @param txBuf buffer to send
          * @param length size of buffer to send
@@ -110,6 +120,19 @@ class Spi {
          */
         uint8_t* write(uint8_t* txBuf, int length) {
             return mraa_spi_write_buf(m_spi, txBuf, length);
+        }
+
+        /**
+         * Write buffer of bytes to SPI device The pointer return has to be
+         * free'd by the caller. It will return a NULL pointer in cases of
+         * error
+         *
+         * @param txBuf buffer to send
+         * @param length size of buffer (in bytes) to send
+         * @return uint8_t* data received on the miso line. Same length as passed in
+         */
+        uint16_t* write_uint16(uint16_t* txBuf, int length) {
+            return mraa_spi_write_buf_uint16(m_spi, txBuf, length);
         }
 
 #ifndef SWIG
@@ -124,6 +147,19 @@ class Spi {
          */
         mraa_result_t transfer(uint8_t* txBuf, uint8_t* rxBuf, int length) {
             return mraa_spi_transfer_buf(m_spi, txBuf, rxBuf, length);
+        }
+
+        /**
+         * Transfer data to and from SPI device Receive pointer may be null if
+         * return data is not needed.
+         *
+         * @param data buffer to send
+         * @param rxBuf buffer to optionally receive data from spi device
+         * @param length size of buffer to send
+         * @return Result of operation
+         */
+        mraa_result_t transfer_uint16(uint16_t* txBuf, uint16_t* rxBuf, int length) {
+            return mraa_spi_transfer_buf_uint16(m_spi, txBuf, rxBuf, length);
         }
 #endif
 

--- a/api/mraa/spi.hpp
+++ b/api/mraa/spi.hpp
@@ -111,8 +111,8 @@ class Spi {
 
         /**
          * Write buffer of bytes to SPI device The pointer return has to be
-	     * free'd by the caller. It will return a NULL pointer in cases of
-	     * error
+         * free'd by the caller. It will return a NULL pointer in cases of
+         * error
          *
          * @param txBuf buffer to send
          * @param length size of buffer to send

--- a/api/mraa/spi.hpp
+++ b/api/mraa/spi.hpp
@@ -105,8 +105,8 @@ class Spi {
          * @param data the byte to send
          * @return data received on the miso line
          */
-        uint16_t write_uint16(uint16_t data) {
-            return mraa_spi_write_uint16(m_spi, (uint16_t) data);
+        uint16_t write_word(uint16_t data) {
+            return mraa_spi_write_word(m_spi, (uint16_t) data);
         }
 
         /**
@@ -131,8 +131,8 @@ class Spi {
          * @param length size of buffer (in bytes) to send
          * @return uint8_t* data received on the miso line. Same length as passed in
          */
-        uint16_t* write_uint16(uint16_t* txBuf, int length) {
-            return mraa_spi_write_buf_uint16(m_spi, txBuf, length);
+        uint16_t* write_word(uint16_t* txBuf, int length) {
+            return mraa_spi_write_buf_word(m_spi, txBuf, length);
         }
 
 #ifndef SWIG
@@ -158,8 +158,8 @@ class Spi {
          * @param length size of buffer to send
          * @return Result of operation
          */
-        mraa_result_t transfer_uint16(uint16_t* txBuf, uint16_t* rxBuf, int length) {
-            return mraa_spi_transfer_buf_uint16(m_spi, txBuf, rxBuf, length);
+        mraa_result_t transfer_word(uint16_t* txBuf, uint16_t* rxBuf, int length) {
+            return mraa_spi_transfer_buf_word(m_spi, txBuf, rxBuf, length);
         }
 #endif
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable (mmap-io2 mmap-io2.c)
 add_executable (blink_onboard blink_onboard.c)
 add_executable (uart_setup uart_setup.c)
 add_executable (gpio gpio.c)
+add_executable (spi_max7219 spi_max7219.c)
 
 include_directories(${PROJECT_SOURCE_DIR}/api)
 
@@ -25,6 +26,7 @@ target_link_libraries (mmap-io2 mraa)
 target_link_libraries (blink_onboard mraa)
 target_link_libraries (uart_setup mraa)
 target_link_libraries (gpio mraa)
+target_link_libraries (spi_max7219 mraa)
 
 add_subdirectory (c++)
 

--- a/examples/spi_max7219.c
+++ b/examples/spi_max7219.c
@@ -1,0 +1,87 @@
+/*
+ * Author: Michael Ring <mail@michael-ring.org>
+ * Author: Thomas Ingleby <thomas.c.ingleby@intel.com>
+ * Copyright (c) 2014 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "mraa.h"
+#include <unistd.h>
+#include <stdint.h>
+
+int
+main(int argc, char **argv) {
+//! [Interesting]
+    mraa_spi_context spi;
+    spi = mraa_spi_init(1);
+    if (spi == NULL) {
+        printf("Initialization of spi failed, check syslog for details, exit...\n");
+        exit(1);
+    }
+
+    printf("SPI initialised successfully\n");
+
+    mraa_spi_frequency(spi, 400000);
+    mraa_spi_lsbmode(spi, 0);
+
+    // The MAX7219/21 Chip needs the data in word size
+    if (mraa_spi_bit_per_word(spi, 16) != MRAA_SUCCESS) {
+        printf("Could not set SPI Device to 16Bit mode, exit...\n");
+        exit(1);
+    };
+
+    mraa_spi_write_uint16(spi, 0x0900);  // Do not decode bits
+    mraa_spi_write_uint16(spi, 0x0a05);  // Brightness of LEDs
+    mraa_spi_write_uint16(spi, 0x0b07);  // Show all Scan Lines
+    mraa_spi_write_uint16(spi, 0x0c01);  // Display on
+    mraa_spi_write_uint16(spi, 0x0f00);  // Testmode off
+
+    // Display Pattern on the display
+    uint16_t dataAA55[] = {0x01aa, 0x0255, 0x03aa, 0x0455, 0x05aa, 0x0655, 0x07aa, 0x0855};
+    mraa_spi_write_buf_uint16(spi, dataAA55, 16);
+
+    sleep(2);
+
+    // Display inverted Pattern
+    uint16_t data55AA[] = {0x0155, 0x02aa, 0x0355, 0x04aa, 0x0555, 0x06aa, 0x0755, 0x08aa};
+    mraa_spi_write_buf_uint16(spi, data55AA, 16);
+
+    sleep(2);
+
+    // Clear the display
+    uint16_t data[] = {0x0100, 0x0200, 0x0300, 0x0400, 0x0500, 0x0600, 0x0700, 0x0800};
+    mraa_spi_write_buf_uint16(spi, data, 16);
+
+    int i;
+    int j;
+    // cycle through all LED's
+    for (i = 1; i <= 8; i++) {
+        for (j = 0; j < 8; j++) {
+            mraa_spi_write_uint16(spi, (i << 8) + (1 << j));
+            sleep(1);
+        }
+        mraa_spi_write_uint16(spi, i << 8);
+    }
+
+    mraa_spi_stop(spi);
+
+//! [Interesting]
+}

--- a/examples/spi_max7219.c
+++ b/examples/spi_max7219.c
@@ -48,37 +48,37 @@ main(int argc, char **argv) {
         exit(1);
     };
 
-    mraa_spi_write_uint16(spi, 0x0900);  // Do not decode bits
-    mraa_spi_write_uint16(spi, 0x0a05);  // Brightness of LEDs
-    mraa_spi_write_uint16(spi, 0x0b07);  // Show all Scan Lines
-    mraa_spi_write_uint16(spi, 0x0c01);  // Display on
-    mraa_spi_write_uint16(spi, 0x0f00);  // Testmode off
+    mraa_spi_write_word(spi, 0x0900);  // Do not decode bits
+    mraa_spi_write_word(spi, 0x0a05);  // Brightness of LEDs
+    mraa_spi_write_word(spi, 0x0b07);  // Show all Scan Lines
+    mraa_spi_write_word(spi, 0x0c01);  // Display on
+    mraa_spi_write_word(spi, 0x0f00);  // Testmode off
 
     // Display Pattern on the display
     uint16_t dataAA55[] = {0x01aa, 0x0255, 0x03aa, 0x0455, 0x05aa, 0x0655, 0x07aa, 0x0855};
-    mraa_spi_write_buf_uint16(spi, dataAA55, 16);
+    mraa_spi_write_buf_word(spi, dataAA55, 16);
 
     sleep(2);
 
     // Display inverted Pattern
     uint16_t data55AA[] = {0x0155, 0x02aa, 0x0355, 0x04aa, 0x0555, 0x06aa, 0x0755, 0x08aa};
-    mraa_spi_write_buf_uint16(spi, data55AA, 16);
+    mraa_spi_write_buf_word(spi, data55AA, 16);
 
     sleep(2);
 
     // Clear the display
     uint16_t data[] = {0x0100, 0x0200, 0x0300, 0x0400, 0x0500, 0x0600, 0x0700, 0x0800};
-    mraa_spi_write_buf_uint16(spi, data, 16);
+    mraa_spi_write_buf_word(spi, data, 16);
 
     int i;
     int j;
     // cycle through all LED's
     for (i = 1; i <= 8; i++) {
         for (j = 0; j < 8; j++) {
-            mraa_spi_write_uint16(spi, (i << 8) + (1 << j));
+            mraa_spi_write_word(spi, (i << 8) + (1 << j));
             sleep(1);
         }
-        mraa_spi_write_uint16(spi, i << 8);
+        mraa_spi_write_word(spi, i << 8);
     }
 
     mraa_spi_stop(spi);

--- a/src/spi/spi.c
+++ b/src/spi/spi.c
@@ -257,7 +257,7 @@ mraa_spi_write(mraa_spi_context dev, uint8_t data)
 }
 
 uint16_t
-mraa_spi_write_uint16(mraa_spi_context dev, uint16_t data) {
+mraa_spi_write_word(mraa_spi_context dev, uint16_t data) {
     struct spi_ioc_transfer msg;
     memset(&msg, 0, sizeof(msg));
 
@@ -297,7 +297,7 @@ mraa_spi_transfer_buf(mraa_spi_context dev, uint8_t* data, uint8_t* rxbuf, int l
 }
 
 mraa_result_t
-mraa_spi_transfer_buf_uint16(mraa_spi_context dev, uint16_t *data, uint16_t *rxbuf, int length) {
+mraa_spi_transfer_buf_word(mraa_spi_context dev, uint16_t *data, uint16_t *rxbuf, int length) {
     struct spi_ioc_transfer msg;
     memset(&msg, 0, sizeof(msg));
 
@@ -327,10 +327,10 @@ mraa_spi_write_buf(mraa_spi_context dev, uint8_t* data, int length)
 }
 
 uint16_t *
-mraa_spi_write_buf_uint16(mraa_spi_context dev, uint16_t *data, int length) {
+mraa_spi_write_buf_word(mraa_spi_context dev, uint16_t *data, int length) {
     uint16_t* recv = malloc(sizeof(uint16_t) * length);
 
-    if (mraa_spi_transfer_buf_uint16(dev, data, recv, length) != MRAA_SUCCESS) {
+    if (mraa_spi_transfer_buf_word(dev, data, recv, length) != MRAA_SUCCESS) {
         free(recv);
         return NULL;
     }


### PR DESCRIPTION
I have added Initialization for SPI, reason is that on Beaglebone Black SPI fails when not properly initialized.
The example shows how to use 16 bit transfers, this is usefull for devices like the max7219 that work with SPI in 16 bit mode. The 16bit mode should also make it possible to use 9Bit mode on Raspberry Pi, but I did not test this.