### PR TITLE
api/mraa/src/arm/raspberry_pi.c fixed cut & waste error, wrong pin numbe...

### DIFF
--- a/src/arm/raspberry_pi.c
+++ b/src/arm/raspberry_pi.c
@@ -259,7 +259,7 @@ mraa_raspberry_pi() {
                 }
                 else {
                     b->platform_name = PLATFORM_NAME_RASPBERRY_PI_B_REV_1;
-                    platform_detected = PLATFORM_RASPBERRY_PI_B_PLUS_REV_1;
+                    platform_detected = PLATFORM_RASPBERRY_PI_B_REV_1;
                     b->phy_pin_count = MRAA_RASPBERRY_PI_B_REV_1_PINCOUNT;
                 }
             }


### PR DESCRIPTION
Fixed exception when loading mraa on an undetected device

Signed-off-by: Michael Ring <mail@michael-ring.org>