### PR TITLE
I2C functions to read multiple bytes from a register offset

### DIFF
--- a/api/mraa/i2c.h
+++ b/api/mraa/i2c.h
@@ -116,6 +116,17 @@ uint8_t mraa_i2c_read_byte_data(mraa_i2c_context dev, const uint8_t command);
 uint16_t mraa_i2c_read_word_data(mraa_i2c_context dev, const uint8_t command);
 
 /**
+ * Bulk read from i2c context, starting from designated register
+ *
+ * @param dev The i2c context
+ * @param command The register
+ * @param data pointer to the byte array to read data in to
+ * @param length max number of bytes to read
+ * @return The length in bytes passed to the function or 0
+ */
+int mraa_i2c_read_bytes_data(mraa_i2c_context dev, uint8_t command, uint8_t* data, int length);
+
+/**
  * Write length bytes to the bus, the first byte in the array is the
  * command/register to write
  *

--- a/api/mraa/i2c.hpp
+++ b/api/mraa/i2c.hpp
@@ -102,7 +102,7 @@ class I2c {
         }
 
         /**
-	 * Read length bytes from the bus into *data pointer
+	     * Read length bytes from the bus into *data pointer
          *
          * @param data Data to read into
          * @param length Size of read in bytes to make
@@ -133,6 +133,19 @@ class I2c {
         }
 
         /**
+         * Read length bytes from the bus into *data pointer starting from
+         * an i2c register
+         *
+         * @param reg Register to read from
+         * @param data pointer to the byte array to read data in to
+         * @param length max number of bytes to read
+         * @return length passed to the function or 0
+         */
+        int readBytesReg(uint8_t reg, uint8_t* data, int length) {
+            return mraa_i2c_read_bytes_data(m_i2c, reg, data, length);
+        }
+
+        /**
          * Write a byte on the bus
          *
          * @param data The byte to send on the bus
@@ -150,7 +163,7 @@ class I2c {
          * @param length Size of buffer to send
          * @return Result of operation
          */
-        mraa_result_t write(const uint8_t* data, int length) {
+        mraa_result_t write(const uint8_t *data, int length) {
             return mraa_i2c_write(m_i2c, data, length);
         }
 

--- a/src/i2c/i2c.c
+++ b/src/i2c/i2c.c
@@ -200,6 +200,27 @@ mraa_i2c_read_word_data(mraa_i2c_context dev, uint8_t command)
     return 0xFFFF & d.word;
 }
 
+int
+mraa_i2c_read_bytes_data(mraa_i2c_context dev, uint8_t command,
+        uint8_t* data, int length) {
+    struct i2c_rdwr_ioctl_data d;
+    struct i2c_msg m[2];
+
+    m[0].addr = dev->addr;
+    m[0].flags = I2C_M_RD;
+    m[0].len = 1;
+    m[0].buf = &command;
+    m[1].addr = dev->addr;
+    m[1].flags = 0x00;
+    m[1].len = length;
+    m[1].buf = data;
+
+    d.msgs = m;
+    d.nmsgs = 2;
+
+    return ioctl(dev->fh, I2C_RDWR, &d) < 0 ? -1 : length;
+}
+
 mraa_result_t
 mraa_i2c_write(mraa_i2c_context dev, const uint8_t* data, int length)
 {


### PR DESCRIPTION
These functions allow for a write command to be sent with the address to start from and then a read command without a stop command in between the two.
There is also a commit that fixes some very small formatting errors.