### PR TITLE
Implementation of mraa_get_pin_name

### DIFF
--- a/api/mraa/common.h
+++ b/api/mraa/common.h
@@ -149,6 +149,15 @@ mraa_platform_t mraa_get_platform_type();
  */
 unsigned int mraa_get_pin_count();
 
+/**
+* Get name of pin, board must be initialised.
+*
+* @param pin number
+*
+* @return char* of pin name
+*/
+char* mraa_get_pin_name(int pin);
+
 #ifdef __cplusplus
 }
 #endif

--- a/api/mraa/common.hpp
+++ b/api/mraa/common.hpp
@@ -152,6 +152,19 @@ inline unsigned int getPinCount()
 }
 
 /**
+* Get name of pin, board must be initialised.
+*
+* @param pin number
+*
+* @return char* of pin name
+*/
+    inline std::string getPinName(int pin)
+    {
+        std::string ret_val(mraa_get_pin_name(pin));
+        return ret_val;
+    }
+
+/**
  * Sets the log level to use from 0-7 where 7 is very verbose. These are the
  * syslog log levels, see syslog(3) for more information on the levels.
  *

--- a/examples/gpio.c
+++ b/examples/gpio.c
@@ -64,18 +64,23 @@ list_pins() {
     }
     int i;
     for (i = 0; i < pin_count; ++i) {
-        fprintf(stdout, "%02d ", i);
-        if (mraa_pin_mode_test(i, MRAA_PIN_GPIO))
-            fprintf(stdout, "GPIO ");
-        if (mraa_pin_mode_test(i, MRAA_PIN_I2C))
-            fprintf(stdout, "I2C  ");
-        if (mraa_pin_mode_test(i, MRAA_PIN_SPI))
-            fprintf(stdout, "SPI  ");
-        if (mraa_pin_mode_test(i, MRAA_PIN_PWM))
-            fprintf(stdout, "PWM  ");
-        if (mraa_pin_mode_test(i, MRAA_PIN_UART))
-            fprintf(stdout, "UART ");
-        fprintf(stdout, "\n");
+        if (strcmp(mraa_get_pin_name(i),"INVALID") != 0) {
+            fprintf(stdout, "%02d ", i);
+            fprintf(stdout, "%8s: ", mraa_get_pin_name(i));
+            if (mraa_pin_mode_test(i, MRAA_PIN_GPIO))
+                fprintf(stdout, "GPIO ");
+            if (mraa_pin_mode_test(i, MRAA_PIN_I2C))
+                fprintf(stdout, "I2C  ");
+            if (mraa_pin_mode_test(i, MRAA_PIN_SPI))
+                fprintf(stdout, "SPI  ");
+            if (mraa_pin_mode_test(i, MRAA_PIN_PWM))
+                fprintf(stdout, "PWM  ");
+            if (mraa_pin_mode_test(i, MRAA_PIN_AIO))
+                fprintf(stdout, "AIO  ");
+            if (mraa_pin_mode_test(i, MRAA_PIN_UART))
+                fprintf(stdout, "UART ");
+            fprintf(stdout, "\n");
+        }
     }
 }
 

--- a/include/mraa_internal_types.h
+++ b/include/mraa_internal_types.h
@@ -155,7 +155,7 @@ typedef struct {
  */
 typedef struct {
     /*@{*/
-    char name[8];                      /**< Pin's real world name */
+    char name[9];                      /**< Pin's real world name */
     mraa_pincapabilities_t capabilites; /**< Pin Capabiliites */
     mraa_pin_t gpio; /**< GPIO structure */
     mraa_pin_t pwm;  /**< PWM structure */

--- a/src/mraa.c
+++ b/src/mraa.c
@@ -328,6 +328,17 @@ mraa_file_exist(char *filename) {
 }
 
 char*
+mraa_get_pin_name(int pin)
+{
+    if (plat == NULL) {
+        return NULL;
+    }
+    if (pin > (plat->phy_pin_count -1) || pin < 0)
+        return NULL;
+    return (char*) plat->pins[pin].name;
+}
+
+char*
 mraa_file_unglob(char *filename) {
     glob_t results;
     char *res = NULL;


### PR DESCRIPTION
api/mraa/common.h/.hpp Added definition of mraa_get_pin
include/mraa_internal_types.h Increas size of storage for pin names from 8 to 9, a number of pins need 8 characters to give a meaningful name
src/mraa.c Implemented mraa_get_pin
examples/gpio.c Re-implemented the display of pin names an re-introduced AIO Pins, were they removed on purpose?
Signed-off-by: Michael Ring <mail@michael-ring.org>