### PR TITLE
Pull MRAA UART enhancements

### DIFF
--- a/api/mraa/uart.h
+++ b/api/mraa/uart.h
@@ -1,5 +1,6 @@
 /*
  * Author: Thomas Ingleby <thomas.c.ingleby@intel.com>
+ * Contributions: Jon Trulson <jtrulson@ics.com>
  * Copyright (c) 2014 Intel Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -41,6 +42,15 @@ extern "C" {
 
 #include <stdio.h>
 #include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <termios.h>
+#include <sys/time.h>
+#include <sys/select.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #include "common.h"
 
@@ -62,6 +72,26 @@ mraa_uart_context mraa_uart_init(int uart);
  * @return char pointer of device path
  */
 char* mraa_uart_get_dev_path(mraa_uart_context dev);
+
+/**
+ * Open the TTY device associated with a UART context, and set up the
+ * terminal modes and baud rate.  The TTY is setup for a 'raw'
+ * mode. 81N, no echo or special character handling, such as flow
+ * control or line editing semantics.
+ *
+ * @param dev uart context
+ * @param baud desired baud rate
+ * @return mraa_result_t
+ */
+mraa_result_t mraa_uart_open_dev(mraa_uart_context dev, speed_t baud);
+
+/**
+ * Close a device previously opened with mraa_uart_open_dev().
+ *
+ * @param dev uart context
+ * @return mraa_result_t
+ */
+mraa_result_t mraa_uart_close_dev(mraa_uart_context dev);
 
 #ifdef __cplusplus
 }

--- a/api/mraa/uart.h
+++ b/api/mraa/uart.h
@@ -83,7 +83,7 @@ char* mraa_uart_get_dev_path(mraa_uart_context dev);
  * @param baud desired baud rate
  * @return mraa_result_t
  */
-mraa_result_t mraa_uart_open_dev(mraa_uart_context dev, speed_t baud);
+mraa_result_t mraa_uart_open_dev(mraa_uart_context dev, unsigned int baud);
 
 /**
  * Close a device previously opened with mraa_uart_open_dev().

--- a/api/mraa/uart.h
+++ b/api/mraa/uart.h
@@ -113,6 +113,15 @@ int mraa_uart_read(mraa_uart_context dev, char *buf, size_t len);
  */
 int mraa_uart_write(mraa_uart_context dev, char *buf, size_t len);
 
+/**
+ * Check to see if data is available on the device for reading
+ *
+ * @param dev uart context
+ * @param millis number of milliseconds to wait, or 0 to return immediately
+ * @return 1 if there is data available to read, 0 otherwise
+ */
+mraa_boolean_t
+mraa_uart_data_available(mraa_uart_context dev, unsigned int millis);
 
 #ifdef __cplusplus
 }

--- a/api/mraa/uart.h
+++ b/api/mraa/uart.h
@@ -93,6 +93,27 @@ mraa_result_t mraa_uart_open_dev(mraa_uart_context dev, speed_t baud);
  */
 mraa_result_t mraa_uart_close_dev(mraa_uart_context dev);
 
+/**
+ * Read bytes from the device into a buffer
+ *
+ * @param dev uart context
+ * @param buf buffer pointer
+ * @param len maximum size of buffer
+ * @return the number of bytes read, or -1 if an error occurred
+ */
+int mraa_uart_read(mraa_uart_context dev, char *buf, size_t len);
+
+/**
+ * Write bytes in buffer to a device
+ *
+ * @param dev uart context
+ * @param buf buffer pointer
+ * @param len maximum size of buffer
+ * @return the number of bytes written, or -1 if an error occurred
+ */
+int mraa_uart_write(mraa_uart_context dev, char *buf, size_t len);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/api/mraa/uart.hpp
+++ b/api/mraa/uart.hpp
@@ -85,7 +85,7 @@ class Uart
      * @return mraa_result_t
      */
     mraa_result_t
-    openDevice(speed_t baud)
+    openDevice(unsigned int baud)
     {
         return mraa_uart_open_dev(m_uart, baud);
     }

--- a/api/mraa/uart.hpp
+++ b/api/mraa/uart.hpp
@@ -128,6 +128,21 @@ class Uart
         return mraa_uart_write(m_uart, buf, len);
     }
 
+    /**
+     * Check to see if data is available on the device for reading
+     *
+     * @param millis number of milliseconds to wait, or 0 to return immediately
+     * @return true if there is data available to read, false otherwise
+     */
+     bool
+     dataAvailable(unsigned int millis=0)
+     {
+       if (mraa_uart_data_available(m_uart, millis))
+           return true;
+       else
+           return false;
+     }
+
   private:
     mraa_uart_context m_uart;
 };

--- a/api/mraa/uart.hpp
+++ b/api/mraa/uart.hpp
@@ -1,5 +1,6 @@
 /*
  * Author: Brendan Le Foll <brendan.le.foll@intel.com>
+ * Contributions: Jon Trulson <jtrulson@ics.com>
  * Copyright (c) 2014 Intel Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -57,6 +58,7 @@ class Uart
      */
     ~Uart()
     {
+        closeDevice();
         return;
     }
 
@@ -71,6 +73,33 @@ class Uart
     {
         std::string ret_val(mraa_uart_get_dev_path(m_uart));
         return ret_val;
+    }
+
+    /**
+     * Open the TTY device associated with a UART context, and set up the
+     * terminal modes and baud rate.  The TTY is setup for a 'raw'
+     * mode.  81N, no echo or special character handling, such as flow
+     * control or line editing semantics.
+     *
+     * @param baud desired baud rate
+     * @return mraa_result_t
+     */
+    mraa_result_t
+    openDevice(speed_t baud)
+    {
+        return mraa_uart_open_dev(m_uart, baud);
+    }
+
+    /**
+     * Close a device previously opened with mraa_uart_open_dev().
+     *
+     * @param dev uart context
+     * @return mraa_result_t
+     */
+    mraa_result_t
+    closeDevice()
+    {
+        return mraa_uart_close_dev(m_uart);
     }
 
   private:

--- a/api/mraa/uart.hpp
+++ b/api/mraa/uart.hpp
@@ -102,6 +102,32 @@ class Uart
         return mraa_uart_close_dev(m_uart);
     }
 
+    /**
+     * Read bytes from the device into a buffer
+     *
+     * @param buf buffer pointer
+     * @param len maximum size of buffer
+     * @return the number of bytes read, or -1 if an error occurred
+     */
+    int
+    read(char *buf, size_t len)
+    {
+        return mraa_uart_read(m_uart, buf, len);
+    }
+
+    /**
+     * Write bytes in buffer to a device
+     *
+     * @param buf buffer pointer
+     * @param len maximum size of buffer
+     * @return the number of bytes written, or -1 if an error occurred
+     */
+    int
+    write(char *buf, size_t len)
+    {
+        return mraa_uart_write(m_uart, buf, len);
+    }
+
   private:
     mraa_uart_context m_uart;
 };

--- a/include/mraa_internal_types.h
+++ b/include/mraa_internal_types.h
@@ -92,6 +92,7 @@ struct _uart {
     /*@{*/
     int index; /**< the uart index, as known to the os. */
     char* path; /**< the uart device path. */
+    int fd; /**< file descriptor for device. */
     /*@}*/
 };
 

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -83,6 +83,7 @@ mraa_uart_init(int index)
     memset(dev, 0, sizeof(struct _uart));
 
     dev->index = index;
+    dev->fd = -1;
     dev->path = (char*) plat->uart_dev[index].device_path;
     if (advance_func->uart_init_post != NULL) {
         mraa_result_t ret = advance_func->uart_init_post(dev);

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -172,3 +172,35 @@ mraa_uart_close_dev(mraa_uart_context dev)
     dev->fd = -1;
     return MRAA_SUCCESS;
 }
+
+int
+mraa_uart_read(mraa_uart_context dev, char *buf, size_t len)
+{
+    if (!dev) {
+        syslog(LOG_ERR, "uart: read: context is NULL");
+        return MRAA_ERROR_INVALID_HANDLE;
+    }
+
+    if (dev->fd < 0) {
+        syslog(LOG_ERR, "uart: port is not open");
+        return MRAA_ERROR_INVALID_RESOURCE;
+    }
+
+    return read(dev->fd, buf, len);
+}
+
+int
+mraa_uart_write(mraa_uart_context dev, char *buf, size_t len)
+{
+    if (!dev) {
+        syslog(LOG_ERR, "uart: write: context is NULL");
+        return MRAA_ERROR_INVALID_HANDLE;
+    }
+
+    if (dev->fd < 0) {
+        syslog(LOG_ERR, "uart: port is not open");
+        return MRAA_ERROR_INVALID_RESOURCE;
+    }
+
+    return write(dev->fd, buf, len);
+}

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -31,6 +31,49 @@
 #include "uart.h"
 #include "mraa_internal.h"
 
+// This function takes an unsigned int and converts it to a B* speed_t
+// that can be used with linux termios.
+static speed_t uint2speed(unsigned int speed)
+{
+    switch (speed) {
+    case 0:         return B0; // hangup, not too useful otherwise
+    case 50:        return B50;
+    case 75:        return B75;
+    case 110:       return B110;
+    case 150:       return B150;
+    case 200:       return B200;
+    case 300:       return B300;
+    case 600:       return B600;
+    case 1200:      return B1200;
+    case 1800:      return B1800;
+    case 2400:      return B2400;
+    case 4800:      return B4800;
+    case 9600:      return B9600;
+    case 19200:     return B19200;
+    case 38400:     return B38400;
+    case 57600:     return B57600;
+    case 115200:    return B115200;
+    case 230400:    return B230400;
+    case 460800:    return B460800;
+    case 500000:    return B500000;
+    case 576000:    return B576000;
+    case 921600:    return B921600;
+    case 1000000:   return B1000000;
+    case 1152000:   return B1152000;
+    case 1500000:   return B1500000;
+    case 2000000:   return B2000000;
+    case 2500000:   return B2500000;
+    case 3000000:   return B3000000;
+    case 3500000:   return B3500000;
+    case 4000000:   return B4000000;
+    }
+
+    // if we are here, then an unsupported baudrate was selected.
+    // Report it via syslog and return B9600, a common default.
+    syslog(LOG_ERR, "uart: unsupported baud rate, defaulting to 9600.");
+    return B9600;
+}
+
 mraa_uart_context
 mraa_uart_init(int index)
 {
@@ -112,7 +155,7 @@ mraa_uart_get_dev_path(mraa_uart_context dev)
 }
 
 mraa_result_t
-mraa_uart_open_dev(mraa_uart_context dev, speed_t baud)
+mraa_uart_open_dev(mraa_uart_context dev, unsigned int baud)
 {
     if (!dev) {
         syslog(LOG_ERR, "uart: open: context is NULL");
@@ -144,8 +187,9 @@ mraa_uart_open_dev(mraa_uart_context dev, speed_t baud)
     cfmakeraw(&termio);
 
     // set our baud rates
-    cfsetispeed(&termio, baud);
-    cfsetospeed(&termio, baud);
+    speed_t speed = uint2speed(baud);
+    cfsetispeed(&termio, speed);
+    cfsetospeed(&termio, speed);
 
     // make it so
     if (tcsetattr(dev->fd, TCSAFLUSH, &termio) < 0) {


### PR DESCRIPTION
These commits add some additional capabilities to the UART support in MRAA.

Specifically, the ability to open, close, read and write to a TTY device.

Additionally, a method to check the device (with time out) to see if data is available to be read.

The following MRAA functions are added (along with their .hpp counterparts):

mraa_result_t 
mraa_uart_open_dev(mraa_uart_context dev, speed_t baud)

mraa_result_t 
mraa_uart_close_dev(mraa_uart_context dev)

int 
mraa_uart_read(mraa_uart_context dev, char *buf, size_t len)

int 
mraa_uart_write(mraa_uart_context dev, char *buf, size_t len)

mraa_boolean_t 
mraa_uart_data_available(mraa_uart_context dev, unsigned int millis)
