### PR TITLE
de3815.c: Fix the I2C bus_id incorrect issue

### DIFF
--- a/src/x86/intel_de3815.c
+++ b/src/x86/intel_de3815.c
@@ -115,15 +115,15 @@ mraa_intel_de3815()
     b->pins[17].capabilites = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
 
     // BUS DEFINITIONS
-    b->i2c_bus_count = 2;
+    b->i2c_bus_count = 10;
     b->def_i2c_bus = 0;
-    b->i2c_bus[0].bus_id = 0;
-    b->i2c_bus[0].sda = 12;
-    b->i2c_bus[0].scl = 13;
+    b->i2c_bus[8].bus_id = 8;
+    b->i2c_bus[8].sda = 12;
+    b->i2c_bus[8].scl = 13;
 
-    b->i2c_bus[1].bus_id = 1;
-    b->i2c_bus[1].sda = 14;
-    b->i2c_bus[1].scl = 15;
+    b->i2c_bus[9].bus_id = 9;
+    b->i2c_bus[9].sda = 14;
+    b->i2c_bus[9].scl = 15;
 
     b->spi_bus_count = 1;
     b->def_spi_bus = 0;


### PR DESCRIPTION
Signed-off-by: Yong Li <yong.b.li@intel.com>

I found the I2C bus on DE3815 should be 8 and 9, this change fixes the incorrect bus id