### PR TITLE
Pull various uart fixes

### DIFF
--- a/api/mraa/uart.hpp
+++ b/api/mraa/uart.hpp
@@ -99,19 +99,12 @@ class Uart
      *
      * @param data buffer pointer
      * @param length maximum size of buffer
-     * @return string of data
+     * @return number of bytes read, or -1 on error
      */
-    std::string
-    read(int length)
+    int
+    read(char* data, int length)
     {
-        char* data = (char*) malloc(sizeof(char) * length);
-        int v = mraa_uart_read(m_uart, data, (size_t) length);
-        char* out = (char*) malloc(sizeof(char) * v);
-        strncpy(out, data, v);
-        std::string ret(out);
-        free(data);
-        free(out);
-        return ret;
+        return mraa_uart_read(m_uart, data, length);
     }
 
     /**

--- a/api/mraa/uart.hpp
+++ b/api/mraa/uart.hpp
@@ -111,15 +111,13 @@ class Uart
      * Write bytes in buffer to a device
      *
      * @param data buffer pointer
-     * @param length maximum size of buffer
+     * @param length length of buffer
      * @return the number of bytes written, or -1 if an error occurred
      */
     int
-    write(std::string data)
+    write(char* data, int length)
     {
-        char *d = new char[data.length() + 1];
-        std::strcpy(d, data.c_str());
-        return mraa_uart_write(m_uart, d, (data.length() + 1));
+        return mraa_uart_write(m_uart, data, length);
     }
 
     /**

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -232,6 +232,7 @@ mraa_uart_stop(mraa_uart_context dev)
     // just close the device and reset our fd.
     if (dev->fd >= 0) {
         close(dev->fd);
+        dev->fd = -1;
     }
 
     free(dev);

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -318,7 +318,7 @@ mraa_uart_set_mode(mraa_uart_context dev, int bytesize, mraa_uart_parity_t parit
     // POSIX & linux doesn't support 1.5 and I've got bigger fish to fry
     switch (stopbits) {
         case 1:
-            termio.c_cflag &= CSTOPB;
+            termio.c_cflag &= ~CSTOPB;
             break;
         case 2:
             termio.c_cflag |= CSTOPB;


### PR DESCRIPTION
- uart: undo changes to write() making use of std::string
- uart: revert changes to use a std::string in read()
- uart: fix missing inversion that will clear all other flags
- uart: set fd to -1 after close to prevent accidental re-use
