### PR TITLE
Adding spi_lsbmode_replace() for Galileo Gen1 to return proper error code

### DIFF
--- a/include/mraa_adv_func.h
+++ b/include/mraa_adv_func.h
@@ -61,6 +61,7 @@ typedef struct {
 
     mraa_result_t (*spi_init_pre) (int bus);
     mraa_result_t (*spi_init_post) (mraa_spi_context spi);
+    mraa_result_t (*spi_lsbmode_replace) (mraa_spi_context dev, mraa_boolean_t lsb);
 
     mraa_result_t (*uart_init_pre) (int index);
     mraa_result_t (*uart_init_post) (mraa_uart_context uart);

--- a/include/mraa_internal_types.h
+++ b/include/mraa_internal_types.h
@@ -64,6 +64,19 @@ struct _i2c {
 };
 
 /**
+ * A structure representing the SPI device
+ */
+struct _spi {
+    /*@{*/
+    int devfd;          /**< File descriptor to SPI Device */
+    uint32_t mode;      /**< Spi mode see spidev.h */
+    int clock;          /**< clock to run transactions at */
+    mraa_boolean_t lsb; /**< least significant bit mode */
+    unsigned int bpw;   /**< Bits per word */
+    /*@}*/
+};
+
+/**
  * A structure representing a PWM pin
  */
 struct _pwm {

--- a/src/spi/spi.c
+++ b/src/spi/spi.c
@@ -36,19 +36,6 @@
 #define MAX_SIZE 64
 #define SPI_MAX_LENGTH 4096
 
-/**
- * A structure representing the SPI device
- */
-struct _spi {
-    /*@{*/
-    int devfd;          /**< File descriptor to SPI Device */
-    uint32_t mode;      /**< Spi mode see spidev.h */
-    int clock;          /**< clock to run transactions at */
-    mraa_boolean_t lsb; /**< least significant bit mode */
-    unsigned int bpw;   /**< Bits per word */
-    /*@}*/
-};
-
 mraa_spi_context
 mraa_spi_init(int bus)
 {

--- a/src/spi/spi.c
+++ b/src/spi/spi.c
@@ -196,6 +196,10 @@ mraa_spi_frequency(mraa_spi_context dev, int hz)
 mraa_result_t
 mraa_spi_lsbmode(mraa_spi_context dev, mraa_boolean_t lsb)
 {
+    if (advance_func->spi_lsbmode_replace != NULL) {
+        return advance_func->spi_lsbmode_replace(dev, lsb);
+    }
+
     uint8_t lsb_mode = (uint8_t) lsb;
     if (ioctl(dev->devfd, SPI_IOC_WR_LSB_FIRST, &lsb_mode) < 0) {
         syslog(LOG_ERR, "spi: Failed to set bit order");


### PR DESCRIPTION
This is for issue #178, I've implemented the _replace hook (that required some prerequisites to be in place first - all are in separate commits to have a logical separation) to return proper error code.

I haven't tested it on namely Galileo (I don't have a Linux toolchain for Iot DevKit image and couldn't find neither sources nor a prebuilt one - if you have any pointers, I'd be grateful for a suggestion).

However I've tested it on Edison (by adding identical code to Edison't platform file) - worked as expected. By the way Edison seems to also have problems with LSB mode (already captured in issue #22).