### PR TITLE
cmake: add nodejs executable name

### DIFF
--- a/cmake/modules/FindNodejs.cmake
+++ b/cmake/modules/FindNodejs.cmake
@@ -1,4 +1,4 @@
-find_program (NODE_EXECUTABLE NAMES node
+find_program (NODE_EXECUTABLE NAMES node nodejs
     HINTS
     $ENV{NODE_DIR}
     PATH_SUFFIXES bin


### PR DESCRIPTION
The Debian package names the executable nodejs instead of node

Signed-off-by: Justin Brown <justin.m.brown@intel.com>