### PR TITLE
java: fixed missing flags for cross-compiling java bindings

### DIFF
--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories (
 set_source_files_properties (mraajava.i PROPERTIES SWIG_FLAGS ";-package;mraa;-I${CMAKE_BINARY_DIR}/src")
 set_source_files_properties (mraajava.i PROPERTIES CPLUSPLUS ON)
 
-set (CMAKE_CXX_FLAGS "-fpermissive")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
 
 set (JAVAC $ENV{JAVA_HOME}/bin/javac)
 set (JAR $ENV{JAVA_HOME}/bin/jar)


### PR DESCRIPTION
Signed-off-by: Mihai Tudor Panu <mihai.tudor.panu@intel.com>