### PR TITLE
Beaglebone: complete pwm output config & fix some warnings

### DIFF
--- a/src/arm/beaglebone.c
+++ b/src/arm/beaglebone.c
@@ -377,6 +377,12 @@ mraa_beaglebone()
     unsigned int uart3_enabled = 0;
     unsigned int uart4_enabled = 0;
     unsigned int uart5_enabled = 0;
+    unsigned int ehrpwm0a_enabled = 0;
+    unsigned int ehrpwm0b_enabled = 0;
+    unsigned int ehrpwm1a_enabled = 0;
+    unsigned int ehrpwm1b_enabled = 0;
+    unsigned int ehrpwm2a_enabled = 0;
+    unsigned int ehrpwm2b_enabled = 0;
     unsigned int is_rev_c = 0;
     size_t len = 0;
     char* line = NULL;
@@ -445,6 +451,36 @@ mraa_beaglebone()
         uart5_enabled = 1;
     else
         uart5_enabled = 0;
+
+    if (mraa_file_exist("/sys/class/pwm/pwm0"))
+        ehrpwm0a_enabled = 1;
+    else
+        ehrpwm0a_enabled = 0;
+
+    if (mraa_file_exist("/sys/class/pwm/pwm1"))
+        ehrpwm0b_enabled = 1;
+    else
+        ehrpwm0b_enabled = 0;
+
+    if (mraa_file_exist("/sys/class/pwm/pwm3"))
+        ehrpwm1a_enabled = 1;
+    else
+        ehrpwm1a_enabled = 0;
+
+    if (mraa_file_exist("/sys/class/pwm/pwm4"))
+        ehrpwm1b_enabled = 1;
+    else
+        ehrpwm1b_enabled = 0;
+
+    if (mraa_file_exist("/sys/class/pwm/pwm5"))
+        ehrpwm2a_enabled = 1;
+    else
+        ehrpwm2a_enabled = 0;
+
+    if (mraa_file_exist("/sys/class/pwm/pwm6"))
+        ehrpwm2b_enabled = 1;
+    else
+        ehrpwm2b_enabled = 0;
 
     mraa_board_t* b = (mraa_board_t*) malloc(sizeof(mraa_board_t));
     if (b == NULL)
@@ -570,11 +606,17 @@ mraa_beaglebone()
     b->pins[12].gpio.parent_id = 0;
     b->pins[12].gpio.mux_total = 0;
 
-    strncpy(b->pins[13].name, "GPIO23", MRAA_PIN_NAME_SIZE);
-    b->pins[13].capabilites = (mraa_pincapabilities_t){ 1, 1, 1, 0, 0, 0, 0, 0 };
+    if (ehrpwm2b_enabled == 1) {
+        strncpy(b->pins[13].name, "EHRPWM2B", MRAA_PIN_NAME_SIZE);
+        b->pins[13].capabilites = (mraa_pincapabilities_t){ 1, 0, 1, 0, 0, 0, 0, 0 };
+    } else {
+        strncpy(b->pins[13].name, "GPIO23", MRAA_PIN_NAME_SIZE);
+        b->pins[13].capabilites = (mraa_pincapabilities_t){ 1, 1, 1, 0, 0, 0, 0, 0 };
+    }
     b->pins[13].gpio.pinmap = 23;
     b->pins[13].gpio.parent_id = 0;
     b->pins[13].gpio.mux_total = 0;
+    b->pins[13].pwm.mux_total = 0;
 
     strncpy(b->pins[14].name, "GPIO26", MRAA_PIN_NAME_SIZE);
     b->pins[14].capabilites = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
@@ -607,12 +649,17 @@ mraa_beaglebone()
     b->pins[18].gpio.parent_id = 0;
     b->pins[18].gpio.mux_total = 0;
 
-    // TODO PWM_2A
-    strncpy(b->pins[19].name, "GPIO22", MRAA_PIN_NAME_SIZE);
-    b->pins[19].capabilites = (mraa_pincapabilities_t){ 1, 1, 1, 0, 0, 0, 0, 0 };
+    if (ehrpwm2a_enabled == 1) {
+        strncpy(b->pins[19].name, "EHRPWM2A", MRAA_PIN_NAME_SIZE);
+        b->pins[19].capabilites = (mraa_pincapabilities_t){ 1, 0, 1, 0, 0, 0, 0, 0 };
+    } else {
+        strncpy(b->pins[19].name, "GPIO22", MRAA_PIN_NAME_SIZE);
+        b->pins[19].capabilites = (mraa_pincapabilities_t){ 1, 1, 1, 0, 0, 0, 0, 0 };
+    }
     b->pins[19].gpio.pinmap = 22;
     b->pins[19].gpio.parent_id = 0;
     b->pins[19].gpio.mux_total = 0;
+    b->pins[19].pwm.mux_total = 0;
 
     if (emmc_enabled == 1) {
         strncpy(b->pins[20].name, "MMC1_CMD", MRAA_PIN_NAME_SIZE);
@@ -992,26 +1039,36 @@ mraa_beaglebone()
     b->pins[59].gpio.mux_total = 0;
     b->pins[59].uart.mux_total = 0;
 
-    // TODO PWM_1A
-    strncpy(b->pins[60].name, "GPIO40", MRAA_PIN_NAME_SIZE);
-    b->pins[60].capabilites = (mraa_pincapabilities_t){ 1, 1, 1, 0, 0, 0, 0, 0 };
+    if (ehrpwm1a_enabled == 1) {
+        strncpy(b->pins[60].name, "EHRPWM1A", MRAA_PIN_NAME_SIZE);
+        b->pins[60].capabilites = (mraa_pincapabilities_t){ 1, 0, 1, 0, 0, 0, 0, 0 };
+    } else {
+        strncpy(b->pins[60].name, "GPIO50", MRAA_PIN_NAME_SIZE);
+        b->pins[60].capabilites = (mraa_pincapabilities_t){ 1, 1, 1, 0, 0, 0, 0, 0 };
+    }
     b->pins[60].gpio.pinmap = 50;
     b->pins[60].gpio.parent_id = 0;
     b->pins[60].gpio.mux_total = 0;
+    b->pins[60].pwm.mux_total = 0;
 
-    // TODO PWM_TRIP2_IN is this PWM?????
+    // TODO PWM_TRIP2_IN (not a PWM output, but used for sync cf ref. manual)
     strncpy(b->pins[61].name, "GPIO48", MRAA_PIN_NAME_SIZE);
     b->pins[61].capabilites = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
     b->pins[61].gpio.pinmap = 48;
     b->pins[61].gpio.parent_id = 0;
     b->pins[61].gpio.mux_total = 0;
 
-    // TODO PWM_1B
-    strncpy(b->pins[62].name, "GPIO51", MRAA_PIN_NAME_SIZE);
-    b->pins[62].capabilites = (mraa_pincapabilities_t){ 1, 1, 1, 0, 0, 0, 0, 0 };
+    if (ehrpwm1b_enabled == 1) {
+        strncpy(b->pins[62].name, "EHRPWM1B", MRAA_PIN_NAME_SIZE);
+        b->pins[62].capabilites = (mraa_pincapabilities_t){ 1, 0, 1, 0, 0, 0, 0, 0 };
+    } else {
+        strncpy(b->pins[62].name, "GPIO51", MRAA_PIN_NAME_SIZE);
+        b->pins[62].capabilites = (mraa_pincapabilities_t){ 1, 1, 1, 0, 0, 0, 0, 0 };
+    }
     b->pins[62].gpio.pinmap = 51;
     b->pins[62].gpio.parent_id = 0;
     b->pins[62].gpio.mux_total = 0;
+    b->pins[62].pwm.mux_total = 0;
 
     if ((i2c0_enabled == 1) || (spi0_enabled == 1)) {
         if (i2c0_enabled == 1) {
@@ -1077,18 +1134,22 @@ mraa_beaglebone()
     b->pins[66].gpio.mux_total = 0;
     b->pins[66].i2c.mux_total = 0;
 
-    if ((spi0_enabled == 1) || uart2_enabled == 1) {
+    if ((spi0_enabled == 1) || uart2_enabled == 1 || ehrpwm0b_enabled == 1) {
         if (uart2_enabled == 1) {
             strncpy(b->pins[67].name, "UART2_TX", MRAA_PIN_NAME_SIZE);
-            b->pins[67].capabilites = (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 1 };
+            b->pins[67].capabilites = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 1 };
         }
         if (spi0_enabled == 1) {
             strncpy(b->pins[67].name, "SPI0D0", MRAA_PIN_NAME_SIZE);
             b->pins[67].capabilites = (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 0 };
         }
+        if (ehrpwm0b_enabled == 1) {
+            strncpy(b->pins[67].name, "EHRPWM0B", MRAA_PIN_NAME_SIZE);
+            b->pins[67].capabilites = (mraa_pincapabilities_t){ 1, 0, 1, 0, 0, 0, 0, 0 };
+        }
     } else {
         strncpy(b->pins[67].name, "GPIO3", MRAA_PIN_NAME_SIZE);
-        b->pins[67].capabilites = (mraa_pincapabilities_t){ 1, 1, 0, 0, 1, 0, 0, 1 };
+        b->pins[67].capabilites = (mraa_pincapabilities_t){ 1, 1, 1, 0, 1, 0, 0, 1 };
     }
     b->pins[67].gpio.pinmap = 3;
     b->pins[67].gpio.parent_id = 0;
@@ -1096,8 +1157,7 @@ mraa_beaglebone()
     b->pins[67].spi.mux_total = 0;
     b->pins[67].uart.mux_total = 0;
 
-
-    if ((spi0_enabled == 1) || uart2_enabled == 1) {
+    if ((spi0_enabled == 1) || uart2_enabled == 1 || ehrpwm0a_enabled == 1) {
         if (uart2_enabled == 1) {
             strncpy(b->pins[68].name, "UART2_RX", MRAA_PIN_NAME_SIZE);
             b->pins[68].capabilites = (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 1 };
@@ -1106,9 +1166,13 @@ mraa_beaglebone()
             strncpy(b->pins[68].name, "SPI0CLK", MRAA_PIN_NAME_SIZE);
             b->pins[68].capabilites = (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 0 };
         }
+        if (ehrpwm0a_enabled == 1) {
+            strncpy(b->pins[68].name, "EHRPWM0A", MRAA_PIN_NAME_SIZE);
+            b->pins[68].capabilites = (mraa_pincapabilities_t){ 1, 0, 1, 0, 0, 0, 0, 0 };
+        }
     } else {
         strncpy(b->pins[68].name, "GPIO2", MRAA_PIN_NAME_SIZE);
-        b->pins[68].capabilites = (mraa_pincapabilities_t){ 1, 1, 0, 0, 1, 0, 0, 1 };
+        b->pins[68].capabilites = (mraa_pincapabilities_t){ 1, 1, 1, 0, 1, 0, 0, 1 };
     }
     b->pins[68].gpio.pinmap = 2;
     b->pins[68].gpio.parent_id = 0;

--- a/src/arm/beaglebone.c
+++ b/src/arm/beaglebone.c
@@ -31,6 +31,8 @@
 #include "common.h"
 #include "arm/beaglebone.h"
 
+#define NUM2STR(x) #x
+
 #define PLATFORM_NAME_BEAGLEBONE_BLACK_REV_B "Beaglebone Black Rev. B"
 #define PLATFORM_NAME_BEAGLEBONE_BLACK_REV_C "Beaglebone Black Rev. C"
 
@@ -38,9 +40,10 @@
 #define SYSFS_CLASS_PWM "/sys/class/pwm/"
 #define SYSFS_CLASS_MMC "/sys/class/mmc_host/"
 #define SYSFS_PWM_OVERLAY "am33xx_pwm"
-#define UART_OVERLAY "ADAFRUIT-UART%d"
+#define UART_OVERLAY(x) "ADAFRUIT-UART" NUM2STR(x)
 //#define ADAFRUIT_SPI_OVERLAY "ADAFRUIT-SPI%d"
-#define SPI_OVERLAY "BB-SPI%d-01"
+#define SPI_OVERLAY(x) "BB-SPI" NUM2STR(x) "-01"
+#define I2C_OVERLAY(x) "ADAFRUIT-I2C" NUM2STR(x)
 #define MAX_SIZE 64
 
 #define MMAP_PATH "/dev/mem"
@@ -197,7 +200,7 @@ mraa_beaglebone_uart_init_pre(int index)
             syslog(LOG_ERR, "uart: Failed to open %s for writing, check access rights for user", capepath);
             return ret;
         }
-        if (fprintf(fh, UART_OVERLAY, index + 1) < 0) {
+        if (fprintf(fh, UART_OVERLAY(index + 1)) < 0) {
             syslog(LOG_ERR, "uart: Failed to write to CapeManager");
         }
         fclose(fh);
@@ -247,10 +250,10 @@ mraa_beaglebone_spi_init_pre(int index)
             syslog(LOG_ERR, "spi: Failed to open %s for writing, check access rights for user", capepath);
             return ret;
         }
-        if (fprintf(fh, SPI_OVERLAY, index) < 0) {
+        if (fprintf(fh, SPI_OVERLAY(index)) < 0) {
             syslog(LOG_ERR,
                    "spi: Failed to write to CapeManager, check that /lib/firmware/%s exists",
-                   SPI_OVERLAY, index);
+                   SPI_OVERLAY(index));
         }
         fclose(fh);
         free(capepath);
@@ -259,7 +262,7 @@ mraa_beaglebone_spi_init_pre(int index)
         plat->spi_bus[index].bus_id = deviceindex;
         ret = MRAA_SUCCESS;
     } else {
-        syslog(LOG_ERR, "spi: Device not initialized, check that /lib/firmware/%s exists", SPI_OVERLAY, index);
+        syslog(LOG_ERR, "spi: Device not initialized, check that /lib/firmware/%s exists", SPI_OVERLAY(index));
         syslog(LOG_ERR, "spi: Check http://elinux.org/BeagleBone_Black_Enable_SPIDEV for details");
     }
     return ret;
@@ -286,9 +289,9 @@ mraa_beaglebone_i2c_init_pre(unsigned int bus)
             return ret;
         }
         if (fprintf(fh, "ADAFRUIT-I2C%d", bus) < 0) {
-            syslog(LOG_ERR, "i2c: Failed to write to CapeManager, check that "
-                            "/lib/firmware/ADAFRUIT-I2C%d exists",
-                   index);
+            syslog(LOG_ERR,
+                   "i2c: Failed to write to CapeManager, check that /lib/firmware/%s exists",
+                   I2C_OVERLAY(index));
         }
         fclose(fh);
     }
@@ -296,7 +299,8 @@ mraa_beaglebone_i2c_init_pre(unsigned int bus)
         ret = MRAA_SUCCESS;
     else {
         syslog(LOG_ERR,
-               "i2c: Device not initialized, check that /lib/firmware/ADAFRUIT-I2C%d exists", index);
+               "i2c: Device not initialized, check that /lib/firmware/%s exists",
+               I2C_OVERLAY(index));
     }
     return ret;
 }

--- a/src/arm/beaglebone.c
+++ b/src/arm/beaglebone.c
@@ -620,6 +620,7 @@ mraa_beaglebone()
     b->pins[13].gpio.pinmap = 23;
     b->pins[13].gpio.parent_id = 0;
     b->pins[13].gpio.mux_total = 0;
+    b->pins[13].pwm.pinmap = 6;
     b->pins[13].pwm.mux_total = 0;
 
     strncpy(b->pins[14].name, "GPIO26", MRAA_PIN_NAME_SIZE);
@@ -663,6 +664,7 @@ mraa_beaglebone()
     b->pins[19].gpio.pinmap = 22;
     b->pins[19].gpio.parent_id = 0;
     b->pins[19].gpio.mux_total = 0;
+    b->pins[19].pwm.pinmap = 5;
     b->pins[19].pwm.mux_total = 0;
 
     if (emmc_enabled == 1) {
@@ -1053,6 +1055,7 @@ mraa_beaglebone()
     b->pins[60].gpio.pinmap = 50;
     b->pins[60].gpio.parent_id = 0;
     b->pins[60].gpio.mux_total = 0;
+    b->pins[60].pwm.pinmap = 3;
     b->pins[60].pwm.mux_total = 0;
 
     // TODO PWM_TRIP2_IN (not a PWM output, but used for sync cf ref. manual)
@@ -1072,6 +1075,7 @@ mraa_beaglebone()
     b->pins[62].gpio.pinmap = 51;
     b->pins[62].gpio.parent_id = 0;
     b->pins[62].gpio.mux_total = 0;
+    b->pins[62].pwm.pinmap = 4;
     b->pins[62].pwm.mux_total = 0;
 
     if ((i2c0_enabled == 1) || (spi0_enabled == 1)) {
@@ -1160,6 +1164,8 @@ mraa_beaglebone()
     b->pins[67].gpio.mux_total = 0;
     b->pins[67].spi.mux_total = 0;
     b->pins[67].uart.mux_total = 0;
+    b->pins[67].pwm.pinmap = 1;
+    b->pins[67].pwm.mux_total = 0;
 
     if ((spi0_enabled == 1) || uart2_enabled == 1 || ehrpwm0a_enabled == 1) {
         if (uart2_enabled == 1) {
@@ -1183,6 +1189,8 @@ mraa_beaglebone()
     b->pins[68].gpio.mux_total = 0;
     b->pins[68].spi.mux_total = 0;
     b->pins[68].uart.mux_total = 0;
+    b->pins[68].pwm.pinmap = 0;
+    b->pins[68].pwm.mux_total = 0;
 
     // TODO PWM0_SYNCO ?? PWM
     strncpy(b->pins[69].name, "GPIO49", MRAA_PIN_NAME_SIZE);

--- a/src/pwm/pwm.c
+++ b/src/pwm/pwm.c
@@ -274,7 +274,7 @@ mraa_pwm_write(mraa_pwm_context dev, float percentage)
     }
 
     if (percentage > 1.0f) {
-        syslog(LOG_WARNING, "pwm: number greater than 1 entered, defaulting to 100%");
+        syslog(LOG_WARNING, "pwm: number greater than 1 entered, defaulting to 100%%");
         return mraa_pwm_write_duty(dev, dev->period);
     }
     return mraa_pwm_write_duty(dev, percentage * dev->period);


### PR DESCRIPTION
I only added the EHRPWM as outputs. Some EHRPWM outputs have to possible output pins, so maybe there should be a way for the user to chose but I don't know how to do that.
The ECAP should be treated as inputs for signal capture, so I didn't touch that.