### PR TITLE
Mraa.c: Add new API to support I2C bus number query

### DIFF
--- a/api/mraa/common.h
+++ b/api/mraa/common.h
@@ -153,6 +153,24 @@ mraa_platform_t mraa_get_platform_type();
 unsigned int mraa_get_pin_count();
 
 /**
+ * Get platform usable I2C bus count, board must be initialised.
+ *
+ * @return uint of usable I2C bus count on the in-use platform
+ * Function will return -1 on failure
+ */
+int mraa_get_i2c_bus_count();
+
+/**
+ * Get I2C adapter number in sysfs.
+ *
+ * @param i2c_bus the logical I2C bus number
+ *
+ * @return I2C adapter number in sysfs
+ * Function will return -1 on failure
+ */
+int mraa_get_i2c_bus_id(unsigned int i2c_bus);
+
+/**
 * Get name of pin, board must be initialised.
 *
 * @param pin number

--- a/examples/hellomraa.c
+++ b/examples/hellomraa.c
@@ -32,8 +32,16 @@ int
 main(int argc, char** argv)
 {
     char* board_name = mraa_get_platform_name();
+	int i2c_bus, i, i2c_adapter;
 
     fprintf(stdout, "hello mraa\n Version: %s\n Running on %s\n", mraa_get_version(), board_name);
+
+	i2c_bus = mraa_get_i2c_bus_count();
+
+	for (i = 0; i < i2c_bus; i++) {
+		i2c_adapter = mraa_get_i2c_bus_id(i);
+		fprintf(stdout, "I2C[%d] adapter=%d\n", i, i2c_adapter);
+	}
 
     mraa_deinit();
 

--- a/src/mraa.c
+++ b/src/mraa.c
@@ -312,6 +312,29 @@ mraa_get_platform_name()
     return (char*) plat->platform_name;
 }
 
+int
+mraa_get_i2c_bus_count()
+{
+    if (plat == NULL) {
+        return -1;
+    }
+    return plat->i2c_bus_count;
+}
+
+int
+mraa_get_i2c_bus_id(unsigned i2c_bus)
+{
+    if (plat == NULL) {
+        return -1;
+    }
+
+	if (i2c_bus >= plat->i2c_bus_count) {
+		return -1;
+	}
+
+    return plat->i2c_bus[i2c_bus].bus_id;
+}
+
 unsigned int
 mraa_get_pin_count()
 {

--- a/src/x86/intel_minnow_max.c
+++ b/src/x86/intel_minnow_max.c
@@ -152,7 +152,7 @@ mraa_intel_minnow_max()
     mraa_set_pininfo(b, 26, "IBL8254", (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 }, 208);
 
     // Set number of i2c adaptors usable from userspace
-    b->i2c_bus_count = 2;
+    b->i2c_bus_count = 1;
 
     // Configure i2c adaptor #7 and make it the default
     int pin_index_sda, pin_index_scl;


### PR DESCRIPTION
Add two new API to get the usable I2C bus count and related I2C adapter number

Signed-off-by: Yong Li <yong.b.li@intel.com>