### PR TITLE
Edison: Don't initiate SPI pins when initializing MRAA

### DIFF
--- a/src/x86/intel_edison_fab_c.c
+++ b/src/x86/intel_edison_fab_c.c
@@ -247,46 +247,6 @@ mraa_intel_edison_i2c_init_pre(unsigned int bus)
     return MRAA_SUCCESS;
 }
 
-static mraa_result_t
-mraa_intel_edison_misc_spi()
-{
-    mraa_gpio_write(tristate, 0);
-
-    mraa_gpio_context io10_p1 = mraa_gpio_init_raw(263);
-    mraa_gpio_context io10_p2 = mraa_gpio_init_raw(240);
-    mraa_gpio_context io11_p1 = mraa_gpio_init_raw(262);
-    mraa_gpio_context io11_p2 = mraa_gpio_init_raw(241);
-    mraa_gpio_context io12_p1 = mraa_gpio_init_raw(242);
-    mraa_gpio_context io13_p1 = mraa_gpio_init_raw(243);
-    mraa_gpio_dir(io10_p1, MRAA_GPIO_OUT);
-    mraa_gpio_dir(io10_p2, MRAA_GPIO_OUT);
-    mraa_gpio_dir(io11_p1, MRAA_GPIO_OUT);
-    mraa_gpio_dir(io11_p2, MRAA_GPIO_OUT);
-    mraa_gpio_dir(io12_p1, MRAA_GPIO_OUT);
-    mraa_gpio_dir(io13_p1, MRAA_GPIO_OUT);
-
-    mraa_gpio_write(io10_p1, 1);
-    mraa_gpio_write(io10_p2, 0);
-    mraa_gpio_write(io11_p1, 1);
-    mraa_gpio_write(io11_p2, 0);
-    mraa_gpio_write(io12_p1, 0);
-    mraa_gpio_write(io13_p1, 0);
-
-    mraa_gpio_close(io10_p1);
-    mraa_gpio_close(io10_p2);
-    mraa_gpio_close(io11_p1);
-    mraa_gpio_close(io11_p2);
-    mraa_gpio_close(io12_p1);
-    mraa_gpio_close(io13_p1);
-
-    mraa_intel_edison_pinmode_change(115, 1);
-    mraa_intel_edison_pinmode_change(114, 1);
-    mraa_intel_edison_pinmode_change(109, 1);
-    mraa_gpio_write(tristate, 1);
-
-    return MRAA_SUCCESS;
-}
-
 mraa_result_t
 mraa_intel_edison_aio_get_fp(mraa_aio_context dev)
 {
@@ -1162,7 +1122,7 @@ mraa_intel_edison_fab_c()
     }
 
     mraa_gpio_dir(tristate, MRAA_GPIO_OUT);
-    mraa_intel_edison_misc_spi();
+    mraa_gpio_write(tristate, 1);
 
     b->adc_raw = 12;
     b->adc_supported = 10;


### PR DESCRIPTION
My problem is that I have a daemon running in the background that uses the
SPI interface on an Edison/Arduino board. A program using MRAA would disable
the SPI bus when started, so this commit makes MRAA a bit more considerate.

Basic GPIO and SPI functionality has been tested (with Python) after this change.

---

Calling mraa_intel_edison_misc_spi() is not really needed, because the
GPIO 10..13 pins will be configured correctly when the user actually
inits them as GPIO pins. When using these pins for GPIO,
mraa_setup_mux_mapped() and mraa_intel_edison_gpio_init_post() will do
all this work based on the pin map and pinmodes for the Edison Arduino
board.

On the contrary, this function would break any user of the SPI bus
that is already running.