### PR TITLE
Added MinnowBoard Compatible support

### DIFF
--- a/api/mraa/types.h
+++ b/api/mraa/types.h
@@ -41,7 +41,7 @@ typedef enum {
     MRAA_INTEL_GALILEO_GEN2 = 1,    /**< The Generation 2 Galileo platform (RevG/H) */
     MRAA_INTEL_EDISON_FAB_C = 2,    /**< The Intel Edison (FAB C) */
     MRAA_INTEL_DE3815 = 3,          /**< The Intel DE3815 Baytrail NUC */
-    MRAA_INTEL_MINNOWBOARD_MAX = 4, /**< The Intel Minnow Board Max */
+    MRAA_INTEL_MINNOWBOARD_BYT_COMPATIBLE = 4, /**< The Intel Minnow Board Baytrail/MAX/Turbot */
     MRAA_RASPBERRY_PI = 5,          /**< The different Raspberry PI Models -like  A,B,A+,B+ */
     MRAA_BEAGLEBONE = 6,            /**< The different BeagleBone Black Modes B/C */
     MRAA_BANANA = 7,                /**< Allwinner A20 based Banana Pi and Banana Pro */

--- a/api/mraa/types.hpp
+++ b/api/mraa/types.hpp
@@ -42,11 +42,10 @@ typedef enum {
     INTEL_GALILEO_GEN2 = 1,    /**< The Generation 2 Galileo platform (RevG/H) */
     INTEL_EDISON_FAB_C = 2,    /**< The Intel Edison (FAB C) */
     INTEL_DE3815 = 3,          /**< The Intel DE3815 Baytrail NUC */
-    INTEL_MINNOWBOARD_MAX = 4, /**< The Intel Minnow Board Max */
+    MRAA_INTEL_MINNOWBOARD_BYT_COMPATIBLE = 4, /** The Intel Minnow Board Baytrail/MAX/Turbot */
     RASPBERRY_PI = 5,          /**< The different Raspberry PI Models -like  A,B,A+,B+ */
     BEAGLEBONE = 6,            /**< The different BeagleBone Black Modes B/C */
     BANANA = 7,                /**< Allwinner A20 based Banana Pi and Banana Pro */
-
     UNKNOWN_PLATFORM =
     99 /**< An unknown platform type, typically will load INTEL_GALILEO_GEN1 */
 } Platform;

--- a/examples/blink_onboard.c
+++ b/examples/blink_onboard.c
@@ -40,7 +40,7 @@ main(int argc, char** argv)
         case MRAA_INTEL_GALILEO_GEN1:
             gpio = mraa_gpio_init_raw(3);
             break;
-        case MRAA_INTEL_MINNOWBOARD_MAX:
+        case MRAA_INTEL_MINNOWBOARD_BYT_COMPATIBLE:
             // there is no onboard LED that we can flash on the minnowboard max
             // but on the calamari lure pin 21 is an LED. If you don't have the
             // lure put an LED on pin 21
@@ -59,7 +59,7 @@ main(int argc, char** argv)
     }
 
     // on platforms with physical button use gpio_in
-    if (platform == MRAA_INTEL_MINNOWBOARD_MAX) {
+    if (platform == MRAA_INTEL_MINNOWBOARD_BYT_COMPATIBLE) {
         gpio_in = mraa_gpio_init(14);
         if (gpio_in != NULL) {
             mraa_gpio_dir(gpio_in, MRAA_GPIO_IN);

--- a/examples/mraa-i2c.c
+++ b/examples/mraa-i2c.c
@@ -69,7 +69,7 @@ print_bus(mraa_board_t* board)
             case MRAA_INTEL_GALILEO_GEN2:
             case MRAA_INTEL_EDISON_FAB_C:
             case MRAA_INTEL_DE3815:
-            case MRAA_INTEL_MINNOWBOARD_MAX:
+            case MRAA_INTEL_MINNOWBOARD_BYT_COMPATIBLE:
             case MRAA_RASPBERRY_PI:
             case MRAA_BEAGLEBONE:
             case MRAA_BANANA:

--- a/include/x86/intel_minnow_byt_compatible.h
+++ b/include/x86/intel_minnow_byt_compatible.h
@@ -34,7 +34,7 @@ extern "C" {
 #define MRAA_INTEL_MINNOW_MAX_PINCOUNT (26 + 1)
 
 mraa_board_t*
-mraa_intel_minnow_max();
+mraa_intel_minnowboard_byt_compatible();
 
 #ifdef __cplusplus
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,7 @@ set (mraa_LIB_X86_SRCS_NOAUTO
   ${PROJECT_SOURCE_DIR}/src/x86/intel_edison_fab_c.c
   ${PROJECT_SOURCE_DIR}/src/x86/intel_de3815.c
   ${PROJECT_SOURCE_DIR}/src/x86/intel_nuc5.c
-  ${PROJECT_SOURCE_DIR}/src/x86/intel_minnow_max.c
+  ${PROJECT_SOURCE_DIR}/src/x86/intel_minnow_byt_compatible.c
 )
 
 set (mraa_LIB_ARM_SRCS_NOAUTO

--- a/src/x86/intel_minnow_byt_compatible.c
+++ b/src/x86/intel_minnow_byt_compatible.c
@@ -1,5 +1,6 @@
 /*
  * Author: Henry Bruce <henry.bruce@intel.com>
+ * 	   Evan Steele <evan.steele@intel.com>
  * Copyright (c) 2014 Intel Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -28,9 +29,9 @@
 #include <ctype.h>
 
 #include "common.h"
-#include "x86/intel_minnow_max.h"
+#include "x86/intel_minnow_byt_compatible.h"
 
-#define PLATFORM_NAME "MinnowBoard MAX"
+#define PLATFORM_NAME "MinnowBoard"
 #define I2C_BUS_DEFAULT 7
 #define MAX_LENGTH 8
 #define I2CNAME "designware"
@@ -83,7 +84,7 @@ mraa_get_pin_index(mraa_board_t* board, char* name, int* pin_index)
 }
 
 mraa_board_t*
-mraa_intel_minnow_max()
+mraa_intel_minnowboard_byt_compatible()
 {
     mraa_board_t* b = (mraa_board_t*) calloc(1, sizeof(mraa_board_t));
 
@@ -103,7 +104,7 @@ mraa_intel_minnow_max()
     if (b->pins == NULL) {
         goto error;
     }
-
+	
     b->adv_func = (mraa_adv_func_t*) calloc(1, sizeof(mraa_adv_func_t));
     if (b->adv_func == NULL) {
         free(b->pins);
@@ -115,7 +116,6 @@ mraa_intel_minnow_max()
         free(b->adv_func);
         goto error;
     }
-
     sscanf(running_uname.release, "%d.%d", &uname_major, &uname_minor);
 
     /* if we are on Linux 3.17 or lower they use a 256 max and number the GPIOs down
@@ -194,10 +194,9 @@ mraa_intel_minnow_max()
     b->uart_dev[0].rx = -1;
     b->uart_dev[0].tx = -1;
     b->uart_dev[0].device_path = "/dev/ttyS0";
-
     return b;
 error:
-    syslog(LOG_CRIT, "minnowmax: Platform failed to initialise");
+    syslog(LOG_CRIT, "minnow: Platform failed to initialise");
     free(b);
     return NULL;
 }

--- a/src/x86/x86.c
+++ b/src/x86/x86.c
@@ -30,8 +30,8 @@
 #include "x86/intel_galileo_rev_g.h"
 #include "x86/intel_edison_fab_c.h"
 #include "x86/intel_de3815.h"
-#include "x86/intel_minnow_max.h"
 #include "x86/intel_nuc5.h"
+#include "x86/intel_minnow_byt_compatible.h"
 
 mraa_platform_t
 mraa_x86_platform()
@@ -59,15 +59,18 @@ mraa_x86_platform()
                 platform_type = MRAA_INTEL_NUC5;
                 plat = mraa_intel_nuc5();
             } else if (strncmp(line, "NOTEBOOK", 8) == 0) {
-                platform_type = MRAA_INTEL_MINNOWBOARD_MAX;
-                plat = mraa_intel_minnow_max();
+                platform_type = MRAA_INTEL_MINNOWBOARD_BYT_COMPATIBLE;
+                plat = mraa_intel_minnowboard_byt_compatible();
             } else if (strncasecmp(line, "MinnowBoard MAX", 15) == 0) {
-                platform_type = MRAA_INTEL_MINNOWBOARD_MAX;
-                plat = mraa_intel_minnow_max();
+                platform_type = MRAA_INTEL_MINNOWBOARD_BYT_COMPATIBLE;
+                plat = mraa_intel_minnowboard_byt_compatible();
             } else if (strncasecmp(line, "Galileo", 7) == 0) {
                 platform_type = MRAA_INTEL_GALILEO_GEN1;
                 plat = mraa_intel_galileo_rev_d();
-            } else {
+            } else if (strncasecmp(line, "MinnowBoard Compatible", 22) == 0) {
+		platform_type = MRAA_INTEL_MINNOWBOARD_BYT_COMPATIBLE;
+		plat = mraa_intel_minnowboard_byt_compatible();
+	    } else {
                 syslog(LOG_ERR, "Platform not supported, not initialising");
                 platform_type = MRAA_UNKNOWN_PLATFORM;
             }


### PR DESCRIPTION
This change allows libmraa to function with the new ADI Minnowboards. Additionally,
the Minnowboard files were changed to better incorporate new boards, hopefully making
future board additions easier. This change has been tested on the Minnowboard MAX and
the ADI Minnowboard Turbot.

Signed-off-by: Evan Steele <evan.steele@intel.com>