### PR TITLE
uart.hpp: Added missing include for types.hpp

### DIFF
--- a/api/mraa/uart.hpp
+++ b/api/mraa/uart.hpp
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "uart.h"
+#include "types.hpp"
 #include <stdexcept>
 #include <cstring>
 


### PR DESCRIPTION
Looks like uart.hpp is missing the include for types.hpp, which causes the following error when compiling UPM:

```
<cut>
[ 12%] Building CXX object src/grovegprs/CMakeFiles/_pyupm_grovegprs.dir/pyupm_grovegprsPYTHON_wrap.cxx.o
cd /edison_dev/yocto/ww25/out/linux64/build/tmp/work/core2-32-poky-linux/upm/0.3.2+gitAUTOINC+85c602d524-r0/build/src/grovegprs && /edison_dev/yocto/ww25/out/linux64/build/tmp/
sysroots/x86_64-linux/usr/bin/i586-poky-linux/i586-poky-linux-g++   -D_pyupm_grovegprs_EXPORTS -m32 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -mstackrealign -fno-omit-frame
-pointer  --sysroot=/edison_dev/yocto/ww25/out/linux64/build/tmp/sysroots/edison  -O2 -pipe -g -feliminate-unused-debug-types -fvisibility-inlines-hidden -fPIC -I/edison_dev/yo
cto/ww25/out/linux64/build/tmp/work/core2-32-poky-linux/upm/0.3.2+gitAUTOINC+85c602d524-r0/git/src/grovegprs/. -I/edison_dev/yocto/ww25/out/linux64/build/tmp/sysroots/edison/us
r/include/python2.7    -o CMakeFiles/_pyupm_grovegprs.dir/pyupm_grovegprsPYTHON_wrap.cxx.o -c /edison_dev/yocto/ww25/out/linux64/build/tmp/work/core2-32-poky-linux/upm/0.3.2+gi
tAUTOINC+85c602d524-r0/build/src/grovegprs/pyupm_grovegprsPYTHON_wrap.cxx
In file included from /edison_dev/yocto/ww25/out/linux64/build/tmp/work/core2-32-poky-linux/upm/0.3.2+gitAUTOINC+85c602d524-r0/git/src/grovegprs/grovegprs.h:36:0,
                 from /edison_dev/yocto/ww25/out/linux64/build/tmp/work/core2-32-poky-linux/upm/0.3.2+gitAUTOINC+85c602d524-r0/git/src/grovegprs/grovegprs.cxx:27:
/edison_dev/yocto/ww25/out/linux64/build/tmp/sysroots/edison/usr/include/mraa/uart.hpp:173:5: error: 'Result' does not name a type
     Result
     ^
<cut>
```

Or am I missing something here? After fixing this one, there's a whole bunch of further errors when it's not able to convert `mraa_result_t` to `mraa::Result` in all places where it's used in UPM sources (and that's a lot), like the below.

That latter one would be an UPM bug of course, but the scale makes me think if the idea behind is different, because I'd expect those types in UPM to be aligned with the mraa change, and that's apparently not done nor planned (at least not on the issues list). Let me also invite @Propanu  here.

```
<cut>
[ 12%] Building CXX object src/grovegprs/CMakeFiles/_pyupm_grovegprs.dir/pyupm_grovegprsPYTHON_wrap.cxx.o
cd /edison_dev/yocto/ww25/out/linux64/build/tmp/work/core2-32-poky-linux/upm/0.3.2+gitAUTOINC+85c602d524-r0/build/src/grovegprs && /edison_dev/yocto/ww25/out/linux64/build/tmp/
sysroots/x86_64-linux/usr/bin/i586-poky-linux/i586-poky-linux-g++   -D_pyupm_grovegprs_EXPORTS -m32 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -mstackrealign -fno-omit-frame
-pointer  --sysroot=/edison_dev/yocto/ww25/out/linux64/build/tmp/sysroots/edison  -O2 -pipe -g -feliminate-unused-debug-types -fvisibility-inlines-hidden -fPIC -I/edison_dev/yo
cto/ww25/out/linux64/build/tmp/work/core2-32-poky-linux/upm/0.3.2+gitAUTOINC+85c602d524-r0/git/src/grovegprs/. -I/edison_dev/yocto/ww25/out/linux64/build/tmp/sysroots/edison/us
r/include/python2.7    -o CMakeFiles/_pyupm_grovegprs.dir/pyupm_grovegprsPYTHON_wrap.cxx.o -c /edison_dev/yocto/ww25/out/linux64/build/tmp/work/core2-32-poky-linux/upm/0.3.2+gi
tAUTOINC+85c602d524-r0/build/src/grovegprs/pyupm_grovegprsPYTHON_wrap.cxx
/edison_dev/yocto/ww25/out/linux64/build/tmp/work/core2-32-poky-linux/upm/0.3.2+gitAUTOINC+85c602d524-r0/git/src/grovegprs/grovegprs.cxx: In member function 'mraa_result_t upm:
:GroveGPRS::setBaudRate(int)':
/edison_dev/yocto/ww25/out/linux64/build/tmp/work/core2-32-poky-linux/upm/0.3.2+gitAUTOINC+85c602d524-r0/git/src/grovegprs/grovegprs.cxx:72:33: error: cannot convert 'mraa::Result' to 'mraa_result_t' in return
   return m_uart.setBaudRate(baud);
                                 ^
<cut>
```