### PR TITLE
intel_minnow_byt_compatible: fix memory leak

### DIFF
--- a/src/x86/intel_minnow_byt_compatible.c
+++ b/src/x86/intel_minnow_byt_compatible.c
@@ -98,7 +98,6 @@ mraa_intel_minnowboard_byt_compatible()
     b->platform_name = PLATFORM_NAME;
     b->phy_pin_count = MRAA_INTEL_MINNOW_MAX_PINCOUNT;
     b->gpio_count = MRAA_INTEL_MINNOW_MAX_PINCOUNT;
-    b->adv_func = (mraa_adv_func_t*) calloc(1, sizeof(mraa_adv_func_t));
 
     b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_INTEL_MINNOW_MAX_PINCOUNT);
     if (b->pins == NULL) {


### PR DESCRIPTION
mraa_adv_func_t was allocated twice for the adv_func field