### PR TITLE
Fix deadlock in Python console upon isrExit() + a couple of smaller things

### DIFF
--- a/include/mraa_internal_types.h
+++ b/include/mraa_internal_types.h
@@ -47,6 +47,7 @@ struct _gpio {
     void *isr_args; /**< args return when interupt service request triggered */
     pthread_t thread_id; /**< the isr handler thread id */
     int isr_value_fp; /**< the isr file pointer on the value */
+    mraa_boolean_t isr_thread_terminating; /**< is the isr thread being terminated? */
     mraa_boolean_t owner; /**< If this context originally exported the pin */
     mraa_result_t (*mmap_write) (mraa_gpio_context dev, int value);
     int (*mmap_read) (mraa_gpio_context dev);

--- a/src/gpio/gpio.c
+++ b/src/gpio/gpio.c
@@ -87,6 +87,7 @@ mraa_gpio_init_internal(mraa_adv_func_t* func_table, int pin)
 
     dev->value_fp = -1;
     dev->isr_value_fp = -1;
+    dev->isr_thread_terminating = 0;
     dev->phy_pin = -1;
 
     // then check to make sure the pin is exported.
@@ -229,7 +230,7 @@ mraa_gpio_interrupt_handler(void* arg)
 
     for (;;) {
         ret = mraa_gpio_wait_interrupt(dev->isr_value_fp);
-        if (ret == MRAA_SUCCESS) {
+        if (ret == MRAA_SUCCESS && !dev->isr_thread_terminating) {
             pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
 #ifdef SWIGPYTHON
             // In order to call a python object (all python functions are objects) we
@@ -258,7 +259,7 @@ mraa_gpio_interrupt_handler(void* arg)
 #endif
             pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
         } else {
-            // we must have got an error code so die nicely
+            // we must have got an error code or exit request so die nicely
             pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
             close(dev->isr_value_fp);
             dev->isr_value_fp = -1;
@@ -344,6 +345,8 @@ mraa_gpio_isr_exit(mraa_gpio_context dev)
     if (dev->thread_id == 0 && dev->isr_value_fp == -1) {
         return ret;
     }
+    // mark the beginning of the thread termination process for interested parties
+    dev->isr_thread_terminating = 1;
 
     // stop isr being useful
     ret = mraa_gpio_edge_mode(dev, MRAA_GPIO_EDGE_NONE);
@@ -364,6 +367,7 @@ mraa_gpio_isr_exit(mraa_gpio_context dev)
     // assume our thread will exit either way we just lost it's handle
     dev->thread_id = 0;
     dev->isr_value_fp = -1;
+    dev->isr_thread_terminating = 0;
     return ret;
 }
 

--- a/src/gpio/gpio.c
+++ b/src/gpio/gpio.c
@@ -235,7 +235,7 @@ mraa_gpio_interrupt_handler(void* arg)
 #ifdef SWIGPYTHON
             // In order to call a python object (all python functions are objects) we
             // need to aquire the GIL (Global Interpreter Lock). This may not always be
-            // nessecary but especially if doing IO (like print()) python will segfault
+            // necessary but especially if doing IO (like print()) python will segfault
             // if we do not hold a lock on the GIL
             PyGILState_STATE gilstate = PyGILState_Ensure();
             PyObject* arglist;

--- a/src/gpio/gpio.c
+++ b/src/gpio/gpio.c
@@ -247,6 +247,16 @@ mraa_gpio_interrupt_handler(void* arg)
                 ret = PyEval_CallObject((PyObject*) dev->isr, arglist);
                 if (ret == NULL) {
                     syslog(LOG_ERR, "gpio: PyEval_CallObject failed");
+                    PyObject *pvalue, *ptype, *ptraceback;
+                    PyErr_Fetch(&pvalue, &ptype, &ptraceback);
+                    syslog(LOG_ERR, "gpio: the error was %s:%s:%s",
+                           PyString_AsString(PyObject_Str(pvalue)),
+                           PyString_AsString(PyObject_Str(ptype)),
+                           PyString_AsString(PyObject_Str(ptraceback))
+                    );
+                    Py_XDECREF(pvalue);
+                    Py_XDECREF(ptype);
+                    Py_XDECREF(ptraceback);
                 } else {
                     Py_DECREF(ret);
                 }


### PR DESCRIPTION
As mentioned in #268, there's a deadlock between our code that tries to execute the ISR (and obtain the GIL, more specifically) and the `pthread_join()` call in  `isrExit()` - it's getting stuck on `futex()` calls at both ends. This only happens when Python is in the console mode (running from script is okay, futexes are there, but don't deadlock).

I don't see any better way than to introduce a transient flag in `mraa_gpio_context` indicating that the ISR thread is being shut down. Even though the problem at hand is in some sense a corner case, it's anyway not good that we try to execute the ISR upon thread exit.

The chain before the patch is: `pthread_cancel()`->`poll()` returns like there's an interrupt->`read()`->`return MRAA_SUCCESS`->we're executing the ISR in `mraa_gpio_interrupt_handler()`. There seems to be no better way to distinguish `poll()` being interrupted by `pthread_cancel()` and a normal interrupt.

But I wouldn's say I like this approach (adding a flag is so-so), so I'd like to run this by you @arfoll. Any comments or suggestions are more than welcome.

The other two commits are a typo fix and some more elaborated error output in case our ISR fails (helped me during debugging and I think it would be generally useful).