### PR TITLE
Fixed IIO device counting + small typo correction

### DIFF
--- a/src/mraa.c
+++ b/src/mraa.c
@@ -154,7 +154,7 @@ mraa_init()
 
     plat_iio = (mraa_iio_info_t*) calloc(1, sizeof(mraa_iio_info_t));
     // Now detect IIO devices, linux only
-    // find how many i2c buses we have if we haven't already
+    // find how many iio devices we have if we haven't already
     if (num_iio_devices == 0) {
         if (nftw("/sys/bus/iio/devices", &mraa_count_iio_devices, 20, FTW_PHYS) == -1) {
             return MRAA_ERROR_UNSPECIFIED;

--- a/src/mraa.c
+++ b/src/mraa.c
@@ -46,6 +46,7 @@
 #include "version.h"
 
 #define MAX_PLATFORM_NAME_LENGTH 128
+#define IIO_DEVICE_WILDCARD "iio:device*"
 mraa_board_t* plat = NULL;
 mraa_iio_info_t* plat_iio = NULL;
 
@@ -75,10 +76,9 @@ mraa_set_log_level(int level)
 static int
 mraa_count_iio_devices(const char* path, const struct stat* sb, int flag, struct FTW* ftwb)
 {
-    switch (sb->st_mode & S_IFMT) {
-        case S_IFLNK:
-            num_iio_devices++;
-            break;
+    // we are only interested in files with specific names
+    if (fnmatch(IIO_DEVICE_WILDCARD, basename(path), 0) == 0) {
+        num_iio_devices++;
     }
     return 0;
 }


### PR DESCRIPTION
Here comes my take at #299.

A couple of notes:

1. As long as we do name matching, we arguably don't need to check if that's a symlink or not in the counter subroutine, so I removed that.
2. `IIO_DEVICE_WILDCARD` should better be co-located with (and inherited from) similar defines in `iio.c`, however as long as (a) e.g. `MAX_SIZE` (and similar ones) is redefined across various files and (b) it feels like exact header structure/contents for IIO is yet in flux, I've put it right into `mraa.c` - please let me know if you can think of a more appropriate location.