### PR TITLE
Implementation of "get device index by name" (#309) + a fix for potential bug

### DIFF
--- a/api/mraa/iio.h
+++ b/api/mraa/iio.h
@@ -77,6 +77,8 @@ mraa_result_t mraa_iio_trigger_buffer(mraa_iio_context dev, void (*fptr)(char* d
 
 const char* mraa_iio_get_device_name(mraa_iio_context dev);
 
+int mraa_iio_get_device_num_by_name(const char* name);
+
 int mraa_iio_read_size(mraa_iio_context dev);
 
 mraa_iio_channel* mraa_iio_get_channels(mraa_iio_context dev);

--- a/src/iio/iio.c
+++ b/src/iio/iio.c
@@ -163,6 +163,33 @@ mraa_iio_get_device_name(mraa_iio_context dev)
     return dev->name;
 }
 
+int
+mraa_iio_get_device_num_by_name(const char* name)
+{
+    int i;
+
+    if (plat_iio == NULL) {
+        syslog(LOG_ERR, "iio: platform IIO structure is not initialized");
+        return -1;
+    }
+
+    if (name == NULL) {
+        syslog(LOG_ERR, "iio: device name is NULL, unable to find its number");
+        return -1;
+    }
+
+    for (i = 0; i < plat_iio->iio_device_count; i++) {
+        struct _iio* device;
+        device = &plat_iio->iio_devices[i];
+        // we want to check for exact match
+        if (strncmp(device->name, name, strlen(device->name)+1) == 0) {
+            return device->num;
+        }
+    }
+
+    return -1;
+}
+
 mraa_result_t
 mraa_iio_read(mraa_iio_context dev, const char* attr_chan, float* data)
 {

--- a/src/mraa.c
+++ b/src/mraa.c
@@ -173,9 +173,12 @@ mraa_init()
         if (fd > 0) {
             len = read(fd, &name, 64);
             if (len > 1) {
+                // remove any trailing CR/LF symbols
+                name[strcspn(name, "\r\n")] = '\0';
+                len = strlen(name);
                 // use strndup
                 device->name = malloc((sizeof(char) * len) + sizeof(char));
-                strncpy(device->name, name, len);
+                strncpy(device->name, name, len+1);
             }
             close(fd);
         }


### PR DESCRIPTION
The main part is just what #309 is about.

The the second commit is something I've came across during the implementation - we don't normalize IIO device names we read from sysfs and at least on Edison they contain trailing LFs. That may cause unexpected results in downstream consumers of this information.

Example:
```
root@edison1:~# cat /sys/bus/iio/devices/iio\:device0/name |hexdump -C
00000000  62 63 6f 76 65 5f 61 64  63 0a                    |bcove_adc.|
0000000a
root@edison1:~#
```