### PR TITLE
readme: updated link to IoTDevKit package repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ eglibc based yocto poky image that supports opkg. Adding this repository is as
 simple as and you'll have the latest stable tagged build of mraa installed!
 
 ``` bash
-echo "src mraa-upm http://iotdk.intel.com/repos/1.1/intelgalactic" > /etc/opkg/mraa-upm.conf
+echo "src mraa-upm http://iotdk.intel.com/repos/2.0/intelgalactic" > /etc/opkg/mraa-upm.conf
 opkg update
 opkg install libmraa0
 ```
@@ -51,7 +51,7 @@ If you would like to get the latest & greatest builds from master HEAD you can
 use our -dev repository
 
 ```bash
-echo "src mraa-upm http://iotdk.intel.com/repos/1.1/intelgalactic-dev" > /etc/opkg/mraa-upm.conf
+echo "src mraa-upm http://iotdk.intel.com/repos/2.0/intelgalactic-dev" > /etc/opkg/mraa-upm.conf
 opkg update
 opkg install libmraa0
 ```


### PR DESCRIPTION
Looks like the IoT DevKit repo link is outdated and <...>/2.0/<...> is a correct one.