### PR TITLE
use cmake libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ FIND_PACKAGE (Threads REQUIRED)
 
 set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -fno-omit-frame-pointer ")
 set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall ")
-set (LIB_INSTALL_DIR "lib${LIB_SUFFIX}" CACHE PATH "Installation path for libraries")
+set (LIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Installation path for libraries")
 
 # Set CMAKE_LIB_INSTALL_DIR if not defined
 include(GNUInstallDirs)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,7 +100,7 @@ macro (mraa_CREATE_INSTALL_PKGCONFIG generated_file install_location)
   configure_file (${generated_file}.cmake ${CMAKE_CURRENT_BINARY_DIR}/${generated_file} @ONLY)
   install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${generated_file} DESTINATION ${install_location})
 endmacro (mraa_CREATE_INSTALL_PKGCONFIG)
-mraa_create_install_pkgconfig (mraa.pc lib${LIB_SUFFIX}/pkgconfig)
+mraa_create_install_pkgconfig (mraa.pc ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 install(TARGETS mraa DESTINATION ${CMAKE_INSTALL_LIBDIR})
 


### PR DESCRIPTION
Using cmake's libdir variable helps us avoid multilib issues with various distributions.