### PR TITLE
Intel Edison: Add break-out board type to Edison platform name

### DIFF
--- a/src/x86/intel_edison_fab_c.c
+++ b/src/x86/intel_edison_fab_c.c
@@ -33,6 +33,8 @@
 #include "x86/intel_edison_fab_c.h"
 
 #define PLATFORM_NAME "Intel Edison"
+#define PLATFORM_NAME_ARDUINO "Intel Edison (Arduino)"
+#define PLATFORM_NAME_MINIBOARD "Intel Edison (Miniboard)"
 #define SYSFS_CLASS_GPIO "/sys/class/gpio"
 #define SYSFS_PINMODE_PATH "/sys/kernel/debug/gpio_debug/gpio"
 #define MAX_SIZE 64
@@ -1134,9 +1136,11 @@ mraa_intel_edison_fab_c()
         if (mraa_intel_edison_miniboard(b) != MRAA_SUCCESS) {
             goto error;
         }
+		b->platform_name = PLATFORM_NAME_MINIBOARD;
         return b;
     }
     // Now Assuming the edison is attached to the Arduino board.
+    b->platform_name = PLATFORM_NAME_ARDUINO;
     b->phy_pin_count = 20;
     b->gpio_count = 14;
     b->aio_count = 6;


### PR DESCRIPTION
Add detected break-out board (Arduino or Miniboard) to Edison platform name