### PR TITLE
Fix Java IsrCallback crash

### DIFF
--- a/src/java/mraajava.i
+++ b/src/java/mraajava.i
@@ -57,6 +57,7 @@ class Spi;
 %ignore read(char* data, int length);
 
 %feature("director") IsrCallback;
+SWIG_DIRECTOR_OWNED(IsrCallback)
 %include ../mraa.i
 
 %wrapper %{


### PR DESCRIPTION
Fix Java IsrCallback crash: the director now uses a GlobalRef instead of a WeakRef to the IsrCallback object
Related bug: https://github.com/intel-iot-devkit/upm/issues/308

Signed-off-by: Petre Eftime <petre.p.eftime@intel.com>