### PR TITLE
do not require a C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 2.8)
-project (mraa)
+project (mraa C)
 
 FIND_PACKAGE (Threads REQUIRED)
 

--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -1,3 +1,5 @@
+enable_language(CXX)
+
 add_executable (AioA0 AioA0.cpp)
 add_executable (blink-io-cpp Blink-IO.cpp)
 add_executable (Pwm3-cycle Pwm3-cycle.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,6 +171,7 @@ if (DOXYGEN_FOUND)
 endif ()
 
 if (BUILDSWIG)
+  enable_language(CXX)
   find_package (SWIG)
   if (SWIG_FOUND)
     include (${SWIG_USE_FILE})


### PR DESCRIPTION
By default, CMake assumes both a C and C++ compiler are required.
This is not needed for mraa because it only provides C++ header
files.

Signed-off-by: Pieterjan Camerlynck <pieterjan.camerlynck@gmail.com>