### PR TITLE
Using calloc over malloc where appropriate

### DIFF
--- a/src/aio/aio.c
+++ b/src/aio/aio.c
@@ -58,7 +58,7 @@ aio_get_valid_fp(mraa_aio_context dev)
 static mraa_aio_context
 mraa_aio_init_internal(mraa_adv_func_t* func_table)
 {
-    mraa_aio_context dev = malloc(sizeof(struct _aio));
+    mraa_aio_context dev = calloc(1,sizeof(struct _aio));
     if (dev == NULL) {
         return NULL;
     }

--- a/src/arm/96boards.c
+++ b/src/arm/96boards.c
@@ -57,7 +57,7 @@ mraa_board_t* mraa_96boards()
    char ch;
    char name[MRAA_PIN_NAME_SIZE];
 
-   mraa_board_t* b = (mraa_board_t*) malloc(sizeof(mraa_board_t));
+   mraa_board_t* b = (mraa_board_t*) calloc(1,sizeof(mraa_board_t));
    if (b == NULL) {
       return NULL;
    }

--- a/src/arm/banana.c
+++ b/src/arm/banana.c
@@ -199,7 +199,7 @@ mraa_banana_mmap_setup(mraa_gpio_context dev, mraa_boolean_t en)
 mraa_board_t*
 mraa_banana()
 {
-    mraa_board_t* b = (mraa_board_t*) malloc(sizeof(mraa_board_t));
+    mraa_board_t* b = (mraa_board_t*) calloc(1,sizeof(mraa_board_t));
     if (b == NULL) {
         return NULL;
     }

--- a/src/arm/beaglebone.c
+++ b/src/arm/beaglebone.c
@@ -356,7 +356,7 @@ mraa_beaglebone_pwm_init_replace(int pin)
     }
 
     if (mraa_file_exist(devpath)) {
-        mraa_pwm_context dev = (mraa_pwm_context) malloc(sizeof(struct _pwm));
+        mraa_pwm_context dev = (mraa_pwm_context) calloc(1,sizeof(struct _pwm));
         if (dev == NULL)
             return NULL;
         dev->duty_fp = -1;
@@ -488,7 +488,7 @@ mraa_beaglebone()
     else
         ehrpwm2b_enabled = 0;
 
-    mraa_board_t* b = (mraa_board_t*) malloc(sizeof(mraa_board_t));
+    mraa_board_t* b = (mraa_board_t*) calloc(1,sizeof(mraa_board_t));
     if (b == NULL)
         return NULL;
     // TODO: Detect Beaglebone Black Revisions, for now always TYPE B
@@ -512,7 +512,7 @@ mraa_beaglebone()
     b->pwm_max_period = 2147483;
     b->pwm_min_period = 1;
 
-    b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * b->phy_pin_count);
+    b->pins = (mraa_pininfo_t*) calloc(b->phy_pin_count,sizeof(mraa_pininfo_t));
     if (b->pins == NULL) {
         goto error;
     }

--- a/src/arm/raspberry_pi.c
+++ b/src/arm/raspberry_pi.c
@@ -208,14 +208,14 @@ mraa_raspberry_pi_mmap_setup(mraa_gpio_context dev, mraa_boolean_t en)
 mraa_board_t*
 mraa_raspberry_pi()
 {
-    mraa_board_t* b = (mraa_board_t*) malloc(sizeof(mraa_board_t));
+    mraa_board_t* b = (mraa_board_t*) calloc(1,sizeof(mraa_board_t));
     if (b == NULL) {
         return NULL;
     }
     b->phy_pin_count = 0;
 
     size_t len = 100;
-    char* line = malloc(len);
+    char* line = calloc(len,sizeof(char));
 
     FILE* fh = fopen("/proc/cpuinfo", "r");
     if (fh != NULL) {
@@ -280,7 +280,7 @@ mraa_raspberry_pi()
         return NULL;
     }
 
-    b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * b->phy_pin_count);
+    b->pins = (mraa_pininfo_t*) calloc(b->phy_pin_count,sizeof(mraa_pininfo_t));
     if (b->pins == NULL) {
         free(b->adv_func);
         free(b);

--- a/src/glob/glob.c
+++ b/src/glob/glob.c
@@ -899,7 +899,7 @@ globextend(const Char *path, glob_t *pglob, struct glob_limit *limit)
 	    newsize > GLOB_LIMIT_PATH * sizeof(*pathv))
 		goto nospace;
 	pathv = pglob->gl_pathv ? realloc(pglob->gl_pathv, newsize) :
-	    malloc(newsize);
+	    calloc(newsize,sizeof(char *));
 	if (pathv == NULL)
 		return GLOB_NOSPACE;
 

--- a/src/i2c/i2c.c
+++ b/src/i2c/i2c.c
@@ -76,7 +76,7 @@ mraa_i2c_init_internal(mraa_adv_func_t* advance_func, unsigned int bus)
     if (advance_func == NULL)
         return NULL;
 
-    mraa_i2c_context dev = (mraa_i2c_context) malloc(sizeof(struct _i2c));
+    mraa_i2c_context dev = (mraa_i2c_context) calloc(1,sizeof(struct _i2c));
     if (dev == NULL) {
         syslog(LOG_CRIT, "i2c: Failed to allocate memory for context");
         return NULL;

--- a/src/mraa.c
+++ b/src/mraa.c
@@ -578,7 +578,7 @@ mraa_file_contains(const char* filename, const char* content)
     char* file = mraa_file_unglob(filename);
     if (file != NULL) {
         size_t len = 1024;
-        char* line = malloc(len);
+        char* line = calloc(len,sizeof(char));
         if (line == NULL) {
             free(file);
             return 0;
@@ -613,7 +613,7 @@ mraa_file_contains_both(const char* filename, const char* content, const char* c
     char* file = mraa_file_unglob(filename);
     if (file != NULL) {
         size_t len = 1024;
-        char* line = malloc(len);
+        char* line = calloc(len,sizeof(char));
         if (line == NULL) {
             free(file);
             return 0;

--- a/src/pwm/pwm.c
+++ b/src/pwm/pwm.c
@@ -162,7 +162,7 @@ mraa_pwm_read_duty(mraa_pwm_context dev)
 static mraa_pwm_context
 mraa_pwm_init_internal(mraa_adv_func_t* func_table, int chipin, int pin)
 {
-    mraa_pwm_context dev = (mraa_pwm_context) malloc(sizeof(struct _pwm));
+    mraa_pwm_context dev = (mraa_pwm_context) calloc(1,sizeof(struct _pwm));
     if (dev == NULL) {
         return NULL;
     }

--- a/src/usb/ftdi_ft4222.c
+++ b/src/usb/ftdi_ft4222.c
@@ -675,7 +675,7 @@ mraa_ftdi_ft4222()
     sub_plat->platform_name = PLATFORM_NAME;
     sub_plat->phy_pin_count = numUsbPins;
     sub_plat->gpio_count = numUsbGpio;
-    mraa_pininfo_t* pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * numUsbPins);
+    mraa_pininfo_t* pins = (mraa_pininfo_t*) calloc(numUsbPins,sizeof(mraa_pininfo_t));
     if (pins == NULL) {
         return NULL;
     }

--- a/src/x86/intel_de3815.c
+++ b/src/x86/intel_de3815.c
@@ -52,7 +52,7 @@ mraa_intel_de3815()
     b->pwm_max_period = 2147483;
     b->pwm_min_period = 1;
 
-    b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_INTEL_DE3815_PINCOUNT);
+    b->pins = (mraa_pininfo_t*) calloc(MRAA_INTEL_DE3815_PINCOUNT,sizeof(mraa_pininfo_t));
     if (b->pins == NULL) {
         goto error;
     }

--- a/src/x86/intel_edison_fab_c.c
+++ b/src/x86/intel_edison_fab_c.c
@@ -788,7 +788,7 @@ mraa_intel_edison_miniboard(mraa_board_t* b)
     b->pwm_max_period = 218453;
     b->pwm_min_period = 1;
 
-    b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * 56);
+    b->pins = (mraa_pininfo_t*) calloc(56,sizeof(mraa_pininfo_t));
     if (b->pins == NULL) {
         return MRAA_ERROR_UNSPECIFIED;
     }
@@ -1197,7 +1197,7 @@ mraa_intel_edison_fab_c()
     b->adv_func->gpio_mmap_setup = &mraa_intel_edison_mmap_setup;
     b->adv_func->spi_lsbmode_replace = &mraa_intel_edison_spi_lsbmode_replace;
 
-    b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_INTEL_EDISON_PINCOUNT);
+    b->pins = (mraa_pininfo_t*) calloc(MRAA_INTEL_EDISON_PINCOUNT,sizeof(mraa_pininfo_t));
     if (b->pins == NULL) {
         free(b->adv_func);
         goto error;

--- a/src/x86/intel_galileo_rev_d.c
+++ b/src/x86/intel_galileo_rev_d.c
@@ -167,7 +167,7 @@ mraa_intel_galileo_rev_d()
     b->adv_func->gpio_mmap_setup = &mraa_intel_galileo_g1_mmap_setup;
     b->adv_func->spi_lsbmode_replace = &mraa_intel_galileo_g1_spi_lsbmode_replace;
 
-    b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_INTEL_GALILEO_REV_D_PINCOUNT);
+    b->pins = (mraa_pininfo_t*) calloc(MRAA_INTEL_GALILEO_REV_D_PINCOUNT,sizeof(mraa_pininfo_t));
     if (b->pins == NULL) {
         free(b->adv_func);
         goto error;

--- a/src/x86/intel_galileo_rev_g.c
+++ b/src/x86/intel_galileo_rev_g.c
@@ -347,7 +347,7 @@ mraa_intel_galileo_gen2()
     b->adv_func->uart_init_pre = &mraa_intel_galileo_gen2_uart_init_pre;
     b->adv_func->gpio_mmap_setup = &mraa_intel_galileo_g2_mmap_setup;
 
-    b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_INTEL_GALILEO_GEN_2_PINCOUNT);
+    b->pins = (mraa_pininfo_t*) calloc(MRAA_INTEL_GALILEO_GEN_2_PINCOUNT,sizeof(mraa_pininfo_t));
     if (b->pins == NULL) {
         free(b->adv_func);
         goto error;

--- a/src/x86/intel_minnow_byt_compatible.c
+++ b/src/x86/intel_minnow_byt_compatible.c
@@ -99,7 +99,7 @@ mraa_intel_minnowboard_byt_compatible()
     b->phy_pin_count = MRAA_INTEL_MINNOW_MAX_PINCOUNT;
     b->gpio_count = MRAA_INTEL_MINNOW_MAX_PINCOUNT;
 
-    b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_INTEL_MINNOW_MAX_PINCOUNT);
+    b->pins = (mraa_pininfo_t*) calloc(MRAA_INTEL_MINNOW_MAX_PINCOUNT,sizeof(mraa_pininfo_t));
     if (b->pins == NULL) {
         goto error;
     }

--- a/src/x86/intel_nuc5.c
+++ b/src/x86/intel_nuc5.c
@@ -51,7 +51,7 @@ mraa_intel_nuc5()
         goto error;
     }
 
-    b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_INTEL_NUC5_PINCOUNT);
+    b->pins = (mraa_pininfo_t*) calloc(MRAA_INTEL_NUC5_PINCOUNT,sizeof(mraa_pininfo_t));
     if (b->pins == NULL) {
         free(b->adv_func);
         goto error;

--- a/src/x86/intel_sofia_3gr.c
+++ b/src/x86/intel_sofia_3gr.c
@@ -49,7 +49,7 @@ mraa_intel_sofia_3gr()
         goto error;
     }
 
-    b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_INTEL_SOFIA_3GR_PINCOUNT);
+    b->pins = (mraa_pininfo_t*) calloc(MRAA_INTEL_SOFIA_3GR_PINCOUNT,sizeof(mraa_pininfo_t));
     if (b->pins == NULL) {
         free(b->adv_func);
         goto error;


### PR DESCRIPTION
Switch to using calloc on all calls to malloc where the memory isn't initialized. For things like the mraa_board_t, not allocating all to zero causes issues such as with the sub_platform member, where if that's not zero mraa_get_platform_type will try to dereference a random memory location for the sub_platform->platform_name, which can result in segmentation faults and other issues.  

Note that in some places where immediately after the malloc call is a copy operation, there is no need for calloc, as all the memory gets overwritten anyways, but in cases where there may or may not be memory written to (such as in [mraa_file_contains](https://github.com/intel-iot-devkit/mraa/blob/master/src/mraa.c#L581), with reading from a file), even though in most cases the memory is overwritten, it could be the case that the read operation does nothing, but the memory still has non-zero values, by virtue of the fact it wasn't overwritten.

In files : 
* mraa.c
* aio.c
* 96boards.c
* banana.c
* beaglebone.c
* raspberry_pi.c
* glob.c
* i2c.c
* pwm.c
* ft4222.c
* intel_de3815.c
* intel_edison_fab_c.c
* intel_galileo_rev_d.c
* intel_galileo_rev_g.c
* intel_minnow_byt_compatible.c
* intel_nuc5.c
* intel_sofia_3gr.c