### PR TITLE
pwm: Check for out of range pin number in pwm_init()

### DIFF
--- a/src/pwm/pwm.c
+++ b/src/pwm/pwm.c
@@ -186,6 +186,10 @@ mraa_pwm_init(int pin)
         syslog(LOG_NOTICE, "pwm: Using sub platform is not supported");
         return NULL;
     }
+    if (pin < 0 || pin > plat->phy_pin_count) {
+        syslog(LOG_ERR, "pwm: pin %i beyond platform definition", pin);
+        return NULL;
+    }
     if (plat->pins[pin].capabilites.pwm != 1) {
         syslog(LOG_ERR, "pwm: pin not capable of pwm");
         return NULL;


### PR DESCRIPTION
pwm_init() does not check for out of range pin number so can  cause a seg fault.