### PR TITLE
java: Ignored function, which should not have bindings created for it

### DIFF
--- a/src/mraa.i
+++ b/src/mraa.i
@@ -46,7 +46,7 @@
 %ignore Gpio::v8isr(uv_work_t* req);
 %ignore Gpio::v8isr(uv_work_t* req, int status);
 %ignore Gpio::uvwork(void *ctx);
-%ignore Gpio::isr(Edge mode, void (*fptr)(void*), void* args);
+%ignore isr(Edge mode, void (*fptr)(void*), void* args);
 
 %include "gpio.hpp"
 


### PR DESCRIPTION
Signed-off-by: Stefan Andritoiu <stefan.andritoiu@intel.com>