### PR TITLE
mraajs: check for CMAKE version and remove doubled CMAKE_CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ if ("x_${VERSION}" STREQUAL "x_GIT-NOTFOUND" OR "x_${VERSION}" STREQUAL "x_HEAD-
 endif ()
 
 message (INFO " - libmraa Version ${VERSION}")
+message (INFO " - cmake Version ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}")
 
 #parse the version information into pieces.
 string (REGEX REPLACE "^v([0-9]+)\\..*" "\\1" VERSION_MAJOR "${VERSION}")

--- a/docs/building.md
+++ b/docs/building.md
@@ -12,7 +12,7 @@ what you'll need:
 * [git](http://git-scm.com)
 * [python](http://python.org) 2.7 or 3.4+ (you'll need not just the interpreter but python-dev)
 * [node.js](http://nodejs.org) 0.10.x or 0.12.x (you'll need not just the interpreter but nodejs-dev)
-* [CMake](http://cmake.org) 2.8.8+
+* [CMake](http://cmake.org) 2.8.8+ (3.1+ for node.js version 2+)
 
 For Debian-like distros the below command installs the basic set:
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -12,7 +12,7 @@ what you'll need:
 * [git](http://git-scm.com)
 * [python](http://python.org) 2.7 or 3.4+ (you'll need not just the interpreter but python-dev)
 * [node.js](http://nodejs.org) 0.10.x or 0.12.x (you'll need not just the interpreter but nodejs-dev)
-* [CMake](http://cmake.org) 2.8.8+ (3.1+ for node.js version 2+)
+* [CMake](http://cmake.org) 2.8.8+ (3.1+ is recommended for node.js version 2+)
 
 For Debian-like distros the below command installs the basic set:
 

--- a/src/javascript/CMakeLists.txt
+++ b/src/javascript/CMakeLists.txt
@@ -31,14 +31,27 @@ set_target_properties (mraajs PROPERTIES
   SUFFIX ".node"
 )
 
+message (INFO " - swig Version ${SWIG_VERSION}")
+message (INFO " - CXX compiler Version ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+
 if (${V8_VERSION_MAJOR} GREATER 3)
   message (INFO " - Using V8 version > 3 so requiring C++11 compiler")
   # Node 0.12.x V8 engine major version is '3'.
   # Node 2.1.0  V8 engine major version is '4'.
   set_property (TARGET mraajs PROPERTY CXX_STANDARD 11)
   set_property (TARGET mraajs PROPERTY CXX_STANDARD_REQUIRED ON)
-  if((${CMAKE_MAJOR_VERSION} LESS 3) OR (${CMAKE_MAJOR_VERSION} EQUAL 3 AND ${CMAKE_MINOR_VERSION} EQUAL 0))
-    message(FATAL_ERROR " FATAL ERROR: Need to use CMAKE version 3.1+, but it is ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}")
+  if(CMAKE_VERSION VERSION_LESS "3.1")
+    message(INFO " - **WARNING** Need to use CMAKE version 3.1+, but it is ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}")
+    message(INFO " -             So a workaround will be used.")
+    if(CMAKE_COMPILER_IS_GNUCXX)
+      if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7")
+        message(FATAL_ERROR " FATAL ERROR: GNU gcc compiler is also too old (need 4.7+, but ${CMAKE_CXX_COMPILER_VERSION}) and does not support C++11 standard.")
+      endif()
+      set(MRAA_CXX11_WORKAROUND_OPTION "-std=gnu++11")
+    else()
+      set(MRAA_CXX11_WORKAROUND_OPTION "-std=c++11")
+    endif()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MRAA_CXX11_WORKAROUND_OPTION} ")
   endif()
 endif ()
 

--- a/src/javascript/CMakeLists.txt
+++ b/src/javascript/CMakeLists.txt
@@ -25,7 +25,7 @@ swig_add_module (mraajs javascript mraajs.i ${mraa_LIB_SRCS})
 swig_link_libraries (mraajs ${NODE_LIBRARIES} ${mraa_LIBS})
 
 set_target_properties (mraajs PROPERTIES
-  COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -DBUILDING_NODE_EXTENSION -DSWIGJAVASCRIPT=${SWIG_FOUND}"
+  COMPILE_FLAGS " -DBUILDING_NODE_EXTENSION -DSWIGJAVASCRIPT=${SWIG_FOUND}"
   PREFIX ""
   OUTPUT_NAME mraa
   SUFFIX ".node"
@@ -37,6 +37,9 @@ if (${V8_VERSION_MAJOR} GREATER 3)
   # Node 2.1.0  V8 engine major version is '4'.
   set_property (TARGET mraajs PROPERTY CXX_STANDARD 11)
   set_property (TARGET mraajs PROPERTY CXX_STANDARD_REQUIRED ON)
+  if((${CMAKE_MAJOR_VERSION} LESS 3) OR (${CMAKE_MAJOR_VERSION} EQUAL 3 AND ${CMAKE_MINOR_VERSION} EQUAL 0))
+    message(FATAL_ERROR " FATAL ERROR: Need to use CMAKE version 3.1+, but it is ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}")
+  endif()
 endif ()
 
 macro (mraa_CREATE_INSTALL_PACKAGE_JSON generated_file install_location)


### PR DESCRIPTION
1. Check for CMAKE version (it does not support CXX_STANDARD property if 3.0 or less)
2. Remove doubled CMAKE_CXX_FLAGS in mraajs COMPILE_FLAGS

Signed-off-by: Eugene Bolshakov <pub@relvarsoft.com>