### PR TITLE
uart.c: fix build with musl libc

### DIFF
--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -29,9 +29,14 @@
 #include <unistd.h>
 #include <string.h>
 #include <termios.h>
+#include <sys/select.h>
 
 #include "uart.h"
 #include "mraa_internal.h"
+
+#ifndef CMSPAR
+#define CMSPAR   010000000000
+#endif
 
 // This function takes an unsigned int and converts it to a B* speed_t
 // that can be used with linux/posix termios


### PR DESCRIPTION
musl does not define CMSPAR on all archs, patch inspired by
http://git.alpinelinux.org/cgit/aports/plain/main/freerdp/musl-fix.patch

musl needs sys/select.h to provide fd_set.