### PR TITLE
js examples: removed surplus char() helper function

### DIFF
--- a/examples/javascript/bmp85.js
+++ b/examples/javascript/bmp85.js
@@ -26,30 +26,27 @@
 
 var m = require('mraa'); //require mraa
 
-// helper function to go from hex val to dec
-function char(x) { return parseInt(x, 16); }
-
 x = new m.I2c(0)
 x.address(0x77)
 
 // initialise device
-if (x.readReg(char('0xd0')) != char('0x55')) {
+if (x.readReg(0xd0) != 0x55) {
   console.log("error");
 }
 
 // we want to read temperature so write 0x2e into control reg
-x.writeReg(char('0xf4'), char('0x2e'))
+x.writeReg(0xf4, 0x2e)
 
 // read a 16bit reg, obviously it's uncalibrated so mostly a useless value :)
-console.log(x.readWordReg(char('0xf6')))
+console.log(x.readWordReg(0xf6))
 
 // and we can do the same thing with the read()/write() calls if we wished
 // thought I'd really not recommend it!
 buf = new Buffer(2)
-buf[0] = char('0xf4')
-buf[1] = char('0x2e')
+buf[0] = 0xf4
+buf[1] = 0x2e
 console.log(buf.toString('hex'))
 x.write(buf)
 
-x.writeByte(char('0xf6'))
+x.writeByte(0xf6)
 d = x.read(2)

--- a/examples/javascript/rgblcd.js
+++ b/examples/javascript/rgblcd.js
@@ -24,14 +24,11 @@
 
 var m = require('mraa'); //require mraa
 
-// helper function to go from hex val to dec
-function char(x) { return parseInt(x, 16); }
-
 x = new m.I2c(0)
 x.address(0x62)
 x.writeReg(0, 0)
 x.writeReg(1, 0)
 
-x.writeReg(char('0x08'), char('0xAA'))
-x.writeReg(char('0x04'), 255)
-x.writeReg(char('0x02'), 255)
+x.writeReg(0x08, 0xAA)
+x.writeReg(0x04, 255)
+x.writeReg(0x02, 255)

--- a/examples/javascript/spi.js
+++ b/examples/javascript/spi.js
@@ -26,15 +26,12 @@
 
 var m = require('mraa'); //require mraa
 
-// helper function to go from hex val to dec
-function char(x) { return parseInt(x, 16); }
-
 x = new m.Spi(0)
 buf = new Buffer(4)
-buf[0] = char('0xf4')
-buf[1] = char('0x2e')
-buf[2] = char('0x3e')
-buf[3] = char('0x4e')
+buf[0] = 0xf4
+buf[1] = 0x2e
+buf[2] = 0x3e
+buf[3] = 0x4e
 buf2 = x.write(buf)
 console.log("Sent: " + buf.toString('hex') + ". Received: " + buf2.toString('hex'))
 


### PR DESCRIPTION
@arfoll, if you don't mind as the owner of that bug record :smiley: 

I've tested bmp85 and spi examples (not sure what should I have for rgblcd, Grove LCD?) to produce the same results on node 0.10.38 (default in the image) and 0.12.7 (from my repo).