### PR TITLE
intel_edison_fab_c.c: Fixed file descriptor leak in case of read error

### DIFF
--- a/src/x86/intel_edison_fab_c.c
+++ b/src/x86/intel_edison_fab_c.c
@@ -1170,7 +1170,7 @@ is_arduino_board()
     // prepare format string for fscanf, based on MAX_SIZE
     char format_str[MAX_SIZE];
     snprintf(format_str, MAX_SIZE, "%%%ds", MAX_SIZE - 1);
-    int i;
+    int i, ret, errno_saved;
 
     // check tristate first
     tristate = mraa_gpio_init_raw(214);
@@ -1197,14 +1197,16 @@ is_arduino_board()
         }
 
         memset(gpiochip_label, 0, MAX_SIZE);
-        if (fscanf(fp, format_str, &gpiochip_label) != 1) {
+        ret = fscanf(fp, format_str, &gpiochip_label);
+        errno_saved = errno;
+        fclose(fp);
+        if (ret != 1) {
             syslog(LOG_INFO,
                    "edison: could not read from '%s', errno %d",
                    gpiochip_path,
-                   errno);
+                   errno_saved);
             return 0;
         }
-        fclose(fp);
 
         // we want to check for exact match
         if (strncmp(gpiochip_label, gpiochip_label_arduino, strlen(gpiochip_label) + 1) != 0) {


### PR DESCRIPTION
There's a small bug in my previous Arduino board detection patch - in case of GPIO expander label read error we aren't closing the label file properly, which should be fixed.