### PR TITLE
JavaScript, Java and Python bindings now use libmraa.so instread of statically linking

### DIFF
--- a/api/mraa/gpio.h
+++ b/api/mraa/gpio.h
@@ -44,15 +44,8 @@ extern "C" {
 #include <Python.h>
 #endif
 
-#if defined(SWIGJAVA) || defined(JAVACALLBACK)
-#include <jni.h>
-extern JavaVM *globVM;
-extern void mraa_java_isr_callback(void *);
-#endif
-
 #include <stdio.h>
 #include <pthread.h>
-
 #include "common.h"
 
 /**

--- a/api/mraa/gpio.h
+++ b/api/mraa/gpio.h
@@ -40,10 +40,6 @@
 extern "C" {
 #endif
 
-#ifdef SWIGPYTHON
-#include <Python.h>
-#endif
-
 #include <stdio.h>
 #include <pthread.h>
 #include "common.h"

--- a/api/mraa/gpio.hpp
+++ b/api/mraa/gpio.hpp
@@ -28,6 +28,13 @@
 #include "types.hpp"
 #include <stdexcept>
 
+#if defined(SWIGJAVA) || defined(JAVACALLBACK)
+extern "C" {
+    void mraa_java_isr_callback(void *args);
+}
+#endif
+
+
 #if defined(SWIGJAVASCRIPT)
 #if NODE_MODULE_VERSION >= 0x000D
 #include <uv.h>

--- a/examples/java/Isr.java
+++ b/examples/java/Isr.java
@@ -22,6 +22,9 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import mraa.Dir;
 import mraa.Edge;
 import mraa.Gpio;
@@ -37,6 +40,7 @@ public class Isr {
             System.exit(1);
         }
     }
+
     public static void main(String argv[]) throws InterruptedException {
         int pin = 6;
         if (argv.length == 1) {
@@ -45,15 +49,17 @@ public class Isr {
             } catch (Exception e) {
             }
         }
-        System.out.println("Starting ISR for pin " + Integer.toString(pin));
+        BufferedReader console = new BufferedReader(new InputStreamReader(System.in));
+        System.out.println("Starting ISR for pin " + Integer.toString(pin) + ". Press ENTER to stop");
         Gpio gpio = new Gpio(pin);
-
         Runnable callback = new JavaCallback();
-
         gpio.isr(Edge.EDGE_RISING, callback);
-        while (true)
-            Thread.sleep(999999);
-    };
+        try {
+            String input = console.readLine();
+        } catch (IOException e) {
+        }
+        gpio.isrExit();
+    }
 
 }
 

--- a/examples/javascript/gpio-tool.js
+++ b/examples/javascript/gpio-tool.js
@@ -31,8 +31,10 @@ const rl = readline.createInterface({
 });
 
 function printUsage() {
-    console.log("version     Print version");
-    console.log("get pin     Get pin value");
+    console.log("version         Print version");
+    console.log("get pin         Get pin level");
+    console.log("set pin level   Set pin level");
+    console.log("monitor pin     Monitor pin level changes");
 }
 
 function getVersion() {
@@ -55,7 +57,7 @@ function getPin() {
 }
 
 function onPinLevelChange() {
-    console.log('gpio change');
+    console.log('gpio level change');
 }
 
 function monitorPin() {
@@ -65,6 +67,7 @@ function monitorPin() {
     pin.isr(mraa.EDGE_BOTH, onPinLevelChange);
     rl.question('Press ENTER to stop', function(answer) {
         rl.close();
+        pin.isrExit();
     });
 }
 

--- a/examples/python/hello_isr.py
+++ b/examples/python/hello_isr.py
@@ -24,6 +24,7 @@
 
 import mraa
 import time
+import sys
 
 class Counter:
   count = 0
@@ -32,12 +33,19 @@ c = Counter()
 
 # inside a python interupt you cannot use 'basic' types so you'll need to use
 # objects
-def test(args):
-  print("wooo")
+def test(gpio):
+  print("pin " + repr(gpio.getPin(True)) + " = " + repr(gpio.read()))
   c.count+=1
 
-x = mraa.Gpio(6)
+pin = 6;
+if (len(sys.argv) == 2):
+  try:
+    pin = int(sys.argv[1], 10)
+  except ValueError:
+    printf("Invalid pin " + sys.argv[1])
+print("Starting ISR for pin " + repr(pin))
+x = mraa.Gpio(pin)
 x.dir(mraa.DIR_IN)
-x.isr(mraa.EDGE_BOTH, test, test)
-
-time.sleep(500)
+x.isr(mraa.EDGE_BOTH, test, x)
+var = raw_input("Press ENTER to stop")
+x.isrExit()

--- a/include/java/mraajni.h
+++ b/include/java/mraajni.h
@@ -1,0 +1,44 @@
+/*
+ * Author: Henry bruce <henry.bruce@intel.com>
+ * Copyright (c) 2014 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "jni.h"
+#include "mraa/types.h"
+
+void mraa_java_set_jvm(JavaVM* vm);
+void mraa_java_isr_callback(void *args);
+mraa_result_t mraa_java_attach_thread();
+void mraa_java_detach_thread();
+void* mraa_java_create_global_ref(void* args);
+void mraa_java_delete_global_ref(void* ref);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/include/mraa_internal.h
+++ b/include/mraa_internal.h
@@ -34,9 +34,11 @@ extern "C" {
 #include "common.h"
 #include "mraa_internal_types.h"
 #include "mraa_adv_func.h"
+#include "mraa_lang_func.h"
 
 extern mraa_board_t* plat;
 extern mraa_iio_info_t* plat_iio;
+extern mraa_lang_func_t* lang_func;
 
 /**
  * Takes in pin information and sets up the multiplexors.

--- a/include/mraa_lang_func.h
+++ b/include/mraa_lang_func.h
@@ -24,21 +24,12 @@
 
 #pragma once
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+typedef struct {
+    void (*python_isr)(void (*isr)(void*), void* isr_args);
+	void (*java_isr_callback)(void *args);
+	mraa_result_t (*java_attach_thread)();
+	void (*java_detach_thread)();
+	void* (*java_create_global_ref)(void* args);
+	void (*java_delete_global_ref)(void* ref);
 
-#include "jni.h"
-#include "mraa/types.h"
-
-void mraa_java_set_jvm(JavaVM* vm);
-void mraa_java_isr_callback(void *args);
-mraa_result_t mraa_java_attach_thread();
-void mraa_java_detach_thread();
-void* mraa_java_create_global_ref(void* args);
-void mraa_java_delete_global_ref(void* ref);
-
-#ifdef __cplusplus
-}
-#endif
-
+} mraa_lang_func_t;

--- a/include/python/mraapy.h
+++ b/include/python/mraapy.h
@@ -1,0 +1,28 @@
+/*
+ * Author: Henry Bruce <henry.bruce@intel.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+void mraa_python_isr(void (*isr)(void*), void* isr_args);
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,17 +117,6 @@ set (mraa_LIB_GLOB_HEADERS
   ${PROJECT_SOURCE_DIR}/api/mraa.hpp
 )
 
-add_library (mraa ${mraa_LIB_SRCS})
-
-
-target_link_libraries (mraa ${mraa_LIBS})
-
-set_target_properties(
-   mraa
-   PROPERTIES
-   SOVERSION ${mraa_VERSION_MAJOR}
-   VERSION ${mraa_VERSION_STRING}
-)
 install (FILES ${mraa_LIB_GLOB_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install (DIRECTORY ${PROJECT_SOURCE_DIR}/api/mraa/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mraa)
 
@@ -137,7 +126,6 @@ macro (mraa_CREATE_INSTALL_PKGCONFIG generated_file install_location)
 endmacro (mraa_CREATE_INSTALL_PKGCONFIG)
 mraa_create_install_pkgconfig (mraa.pc ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
-install(TARGETS mraa DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 if (DOXYGEN_FOUND)
   set (CMAKE_SWIG_FLAGS -DDOXYGEN=${DOXYGEN_FOUND})
@@ -187,6 +175,15 @@ if (BUILDSWIG)
       add_subdirectory (python)
     endif ()
     if (BUILDSWIGJAVA)
+      FIND_PACKAGE (JNI REQUIRED)
+      include_directories (
+        ${JAVA_INCLUDE_PATH}
+        ${JAVA_INCLUDE_PATH2}
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+      )
+      set (mraa_LIB_SRCS ${mraa_LIB_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/java/mraajni.c)
+      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -DJAVACALLBACK")
+      set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DJAVACALLBACK")
       add_subdirectory (java)
     endif ()
     if (BUILDSWIGNODE)
@@ -198,3 +195,13 @@ if (BUILDSWIG)
     endif ()
   endif ()
 endif ()
+
+add_library (mraa ${mraa_LIB_SRCS})
+target_link_libraries (mraa ${mraa_LIBS})
+set_target_properties(
+   mraa
+   PROPERTIES
+   SOVERSION ${mraa_VERSION_MAJOR}
+   VERSION ${mraa_VERSION_STRING}
+)
+install(TARGETS mraa DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,15 +175,6 @@ if (BUILDSWIG)
       add_subdirectory (python)
     endif ()
     if (BUILDSWIGJAVA)
-      FIND_PACKAGE (JNI REQUIRED)
-      include_directories (
-        ${JAVA_INCLUDE_PATH}
-        ${JAVA_INCLUDE_PATH2}
-        ${CMAKE_CURRENT_SOURCE_DIR}/..
-      )
-      set (mraa_LIB_SRCS ${mraa_LIB_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/java/mraajni.c)
-      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -DJAVACALLBACK")
-      set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DJAVACALLBACK")
       add_subdirectory (java)
     endif ()
     if (BUILDSWIGNODE)

--- a/src/gpio/gpio.c
+++ b/src/gpio/gpio.c
@@ -24,6 +24,9 @@
  */
 #include "gpio.h"
 #include "mraa_internal.h"
+#if defined(SWIGJAVA) || defined(JAVACALLBACK)
+#include "java/mraajni.h"
+#endif
 
 #include <stdlib.h>
 #include <fcntl.h>
@@ -234,35 +237,6 @@ mraa_gpio_wait_interrupt(int fd
     return MRAA_SUCCESS;
 }
 
-#if defined(SWIGJAVA) || defined(JAVACALLBACK)
-pthread_key_t env_key;
-
-extern JavaVM *globVM;
-static pthread_once_t env_key_init = PTHREAD_ONCE_INIT;
-
-jmethodID runGlobal;
-
-static void make_env_key(void)
-{
-
-    JNIEnv *jenv;
-    (*globVM)->GetEnv(globVM, (void **)&jenv, JNI_VERSION_1_8);
-
-    jclass rcls = (*jenv)->FindClass(jenv, "java/lang/Runnable");
-    jmethodID runm = (*jenv)->GetMethodID(jenv, rcls, "run", "()V");
-
-    runGlobal = (jmethodID)(*jenv)->NewGlobalRef(jenv, (jobject)runm);
-
-    pthread_key_create(&env_key, NULL);
-}
-
-void mraa_java_isr_callback(void* data)
-{
-    JNIEnv *jenv = (JNIEnv *) pthread_getspecific(env_key);
-    (*jenv)->CallVoidMethod(jenv, (jobject)data, runGlobal);
-}
-
-#endif
 
 static void*
 mraa_gpio_interrupt_handler(void* arg)
@@ -296,18 +270,12 @@ mraa_gpio_interrupt_handler(void* arg)
     dev->isr_value_fp = fp;
 
 #if defined(SWIGJAVA) || defined(JAVACALLBACK)
-    JNIEnv *jenv;
     if(dev->isr == mraa_java_isr_callback) {
-        jint err = (*globVM)->AttachCurrentThreadAsDaemon(globVM, (void **)&jenv, NULL);
-
-        if (err != JNI_OK) {
-                close(dev->isr_value_fp);
-                dev->isr_value_fp = -1;
-                return NULL;
+        if (mraa_java_attach_thread() != MRAA_SUCCESS) {
+            close(dev->isr_value_fp);
+            dev->isr_value_fp = -1;
+            return NULL;
         }
-
-        pthread_once(&env_key_init, make_env_key);
-        pthread_setspecific(env_key, jenv);
     }
 #endif
 
@@ -403,10 +371,9 @@ mraa_gpio_interrupt_handler(void* arg)
                 dev->isr_value_fp = -1;
             }
 #if defined(SWIGJAVA) || defined(JAVACALLBACK)
-
             if(dev->isr == mraa_java_isr_callback) {
-                (*jenv)->DeleteGlobalRef(jenv, (jobject)dev->isr_args);
-                (*globVM)->DetachCurrentThread(globVM);
+                mraa_java_delete_global_ref(dev->isr_args);
+                mraa_java_detach_thread();
             }
 #endif
             return NULL;
@@ -477,13 +444,10 @@ mraa_gpio_isr(mraa_gpio_context dev, mraa_gpio_edge_t mode, void (*fptr)(void*),
 
     dev->isr = fptr;
 #if defined(SWIGJAVA) || defined(JAVACALLBACK)
-    JNIEnv *jenv;
     /* Most UPM sensors use the C API, the global ref must be created here. */
     /* The reason for checking the callback function is internal callbacks. */
     if (fptr == mraa_java_isr_callback) {
-        (*globVM)->GetEnv(globVM, (void **)&jenv, JNI_VERSION_1_8);
-        jobject grunnable = (*jenv)->NewGlobalRef(jenv, (jobject) args);
-        args = (void *) grunnable;
+        args = mraa_java_create_global_ref(args);
     }
 #endif
     dev->isr_args = args;

--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -1,11 +1,3 @@
-FIND_PACKAGE (JNI REQUIRED)
-
-include_directories (
-  ${JAVA_INCLUDE_PATH}
-  ${JAVA_INCLUDE_PATH2}
-  ${CMAKE_CURRENT_SOURCE_DIR}/..
-)
-
 # SWIG treats SWIG_FLAGS as a list and not a string so semicolon seperation is required
 set_source_files_properties (mraajava.i PROPERTIES SWIG_FLAGS ";-package;mraa;-I${CMAKE_BINARY_DIR}/src")
 set_source_files_properties (mraajava.i PROPERTIES CPLUSPLUS ON)
@@ -25,8 +17,8 @@ else ()
   set (JAR $ENV{JAVA_HOME_NATIVE}/bin/jar)
 endif ()
 
-swig_add_module (mraajava java mraajava.i ${mraa_LIB_SRCS})
-swig_link_libraries (mraajava ${JAVA_LIBRARIES} ${mraa_LIBS})
+swig_add_module (mraajava java mraajava.i)
+swig_link_libraries (mraajava ${JAVA_LIBRARIES} mraa)
 
 add_custom_command (TARGET mraajava
   POST_BUILD

--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -1,3 +1,10 @@
+FIND_PACKAGE (JNI REQUIRED)
+include_directories (
+  ${JAVA_INCLUDE_PATH}
+  ${JAVA_INCLUDE_PATH2}
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
 # SWIG treats SWIG_FLAGS as a list and not a string so semicolon seperation is required
 set_source_files_properties (mraajava.i PROPERTIES SWIG_FLAGS ";-package;mraa;-I${CMAKE_BINARY_DIR}/src")
 set_source_files_properties (mraajava.i PROPERTIES CPLUSPLUS ON)
@@ -17,7 +24,7 @@ else ()
   set (JAR $ENV{JAVA_HOME_NATIVE}/bin/jar)
 endif ()
 
-swig_add_module (mraajava java mraajava.i)
+swig_add_module (mraajava java mraajava.i mraajni.c)
 swig_link_libraries (mraajava ${JAVA_LIBRARIES} mraa)
 
 add_custom_command (TARGET mraajava

--- a/src/java/mraajava.i
+++ b/src/java/mraajava.i
@@ -66,11 +66,20 @@ class Spi;
 
 %wrapper %{
     #include "java/mraajni.h"
+    #include "mraa_lang_func.h"
+    extern mraa_lang_func_t* lang_func;
 
     jint JNI_OnLoad(JavaVM *vm, void *reserved) {
-        /* initialize mraa */
-        mraa_java_set_jvm(vm);
-        mraa_init();
+        /* initialize mraa and set jni functions */
+        mraa_result_t res = mraa_init();
+        if (res == MRAA_SUCCESS || res == MRAA_ERROR_PLATFORM_ALREADY_INITIALISED) {
+            mraa_java_set_jvm(vm);
+            lang_func->java_isr_callback = &mraa_java_isr_callback;
+            lang_func->java_attach_thread  = &mraa_java_attach_thread;
+            lang_func->java_detach_thread = &mraa_java_detach_thread;
+            lang_func->java_create_global_ref = &mraa_java_create_global_ref;
+            lang_func->java_delete_global_ref = &mraa_java_delete_global_ref;
+        }
         return JNI_VERSION_1_8;
     }
 %}

--- a/src/java/mraajava.i
+++ b/src/java/mraajava.i
@@ -65,11 +65,11 @@ class Spi;
 %include ../mraa.i
 
 %wrapper %{
-    JavaVM *globVM;
+    #include "java/mraajni.h"
 
     jint JNI_OnLoad(JavaVM *vm, void *reserved) {
         /* initialize mraa */
-        globVM = vm;
+        mraa_java_set_jvm(vm);
         mraa_init();
         return JNI_VERSION_1_8;
     }

--- a/src/java/mraajni.c
+++ b/src/java/mraajni.c
@@ -1,0 +1,103 @@
+/*
+ * Author: Henry Bruce <henry.bruce@intel.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <pthread.h>
+#include "java/mraajni.h"
+
+static pthread_key_t env_key;
+static pthread_once_t env_key_init = PTHREAD_ONCE_INIT;
+static jmethodID runGlobal;
+static JavaVM* globVM = NULL;
+
+
+void
+mraa_java_set_jvm(JavaVM* vm)
+{
+    globVM = vm;
+}
+
+static void
+mraa_java_make_env_key(void)
+{
+    if (globVM != NULL) {
+        JNIEnv *jenv;
+        (*globVM)->GetEnv(globVM, (void **)&jenv, JNI_VERSION_1_8);
+        jclass rcls = (*jenv)->FindClass(jenv, "java/lang/Runnable");
+        jmethodID runm = (*jenv)->GetMethodID(jenv, rcls, "run", "()V");
+        runGlobal = (jmethodID)(*jenv)->NewGlobalRef(jenv, (jobject)runm);
+        pthread_key_create(&env_key, NULL);
+    }
+}
+
+void
+mraa_java_isr_callback(void* data)
+{
+    JNIEnv *jenv = (JNIEnv *) pthread_getspecific(env_key);
+    (*jenv)->CallVoidMethod(jenv, (jobject)data, runGlobal);
+}
+
+mraa_result_t
+mraa_java_attach_thread()
+{
+    if (globVM != NULL) {
+        JNIEnv *jenv;
+        jint err = (*globVM)->AttachCurrentThreadAsDaemon(globVM, (void **)&jenv, NULL);
+        if (err == JNI_OK) {
+            pthread_once(&env_key_init, mraa_java_make_env_key);
+            pthread_setspecific(env_key, jenv);
+            return MRAA_SUCCESS;
+        }
+    }
+    return MRAA_ERROR_UNSPECIFIED;
+}
+
+void
+mraa_java_detach_thread()
+{
+    if (globVM != NULL)
+        (*globVM)->DetachCurrentThread(globVM);
+}
+
+void*
+mraa_java_create_global_ref(void* args)
+{
+    if (globVM != NULL) {
+        JNIEnv *jenv;
+        (*globVM)->GetEnv(globVM, (void **)&jenv, JNI_VERSION_1_8);
+        jobject grunnable = (*jenv)->NewGlobalRef(jenv, (jobject) args);
+        return (void *)grunnable;
+    } else
+        return NULL;
+}
+
+void
+mraa_java_delete_global_ref(void *ref)
+{
+    if (globVM != NULL) {
+        JNIEnv *jenv;
+        (*globVM)->GetEnv(globVM, (void **)&jenv, JNI_VERSION_1_8);
+        (*jenv)->DeleteGlobalRef(jenv, (jobject)ref);
+    }
+}
+

--- a/src/javascript/CMakeLists.txt
+++ b/src/javascript/CMakeLists.txt
@@ -21,8 +21,8 @@ set_property (SOURCE mraajs.i PROPERTY SWIG_FLAGS "-node"
               "-I${CMAKE_BINARY_DIR}/src" "-DV8_VERSION=${V8_VERSION_HEX}")
 set_source_files_properties (mraajs.i PROPERTIES CPLUSPLUS ON)
 
-swig_add_module (mraajs javascript mraajs.i ${mraa_LIB_SRCS})
-swig_link_libraries (mraajs ${mraa_LIBS})
+swig_add_module (mraajs javascript mraajs.i)
+swig_link_libraries (mraajs mraa)
 
 set_target_properties (mraajs PROPERTIES
   COMPILE_FLAGS " -DBUILDING_NODE_EXTENSION -DSWIGJAVASCRIPT=${SWIG_FOUND}"

--- a/src/mraa.c
+++ b/src/mraa.c
@@ -48,6 +48,7 @@
 #define IIO_DEVICE_WILDCARD "iio:device*"
 mraa_board_t* plat = NULL;
 mraa_iio_info_t* plat_iio = NULL;
+mraa_lang_func_t* lang_func = NULL;
 
 static char* platform_name = NULL;
 static char* platform_long_name = NULL;
@@ -101,8 +102,8 @@ mraa_init()
 #ifdef SWIGPYTHON
     // Initialise python threads, this allows use to grab the GIL when we are
     // required to do so
-    Py_InitializeEx(0);
-    PyEval_InitThreads();
+    // Py_InitializeEx(0);
+    // PyEval_InitThreads();
 #endif
 
     mraa_platform_t platform_type;
@@ -162,6 +163,8 @@ mraa_init()
             strncpy(platform_name, plat->platform_name, length);
         }
     }
+
+    lang_func = (mraa_lang_func_t*) calloc(1, sizeof(mraa_lang_func_t));
 
     syslog(LOG_NOTICE, "libmraa initialised for platform '%s' of type %d", mraa_get_platform_name(), mraa_get_platform_type());
     return MRAA_SUCCESS;

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,7 +1,5 @@
 find_package (PythonLibs ${PYTHONBUILD_VERSION} REQUIRED)
 
-INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
-
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/..
   ${PYTHON_INCLUDE_DIRS}
@@ -9,8 +7,8 @@ include_directories(
 
 set_source_files_properties (mraa.i PROPERTIES CPLUSPLUS ON)
 set_source_files_properties (mraa.i PROPERTIES SWIG_FLAGS "-I${CMAKE_BINARY_DIR}/src")
-swig_add_module (python-mraa python mraa.i ${mraa_LIB_SRCS})
-swig_link_libraries (python-mraa ${PYTHON_LIBRARIES} ${mraa_LIBS})
+swig_add_module (python-mraa python mraa.i mraapy.c)
+swig_link_libraries (python-mraa ${PYTHON_LIBRARIES} mraa)
 
 if (DOXYGEN_FOUND)
   foreach (_file ${DOCCLASSES})

--- a/src/python/mraa.i
+++ b/src/python/mraa.i
@@ -149,6 +149,17 @@ class Spi;
 %include ../mraa.i
 
 %init %{
-    //Adding mraa_init() to the module initialisation process
-    mraa_init();
+    #include "python/mraapy.h"
+    #include "mraa_lang_func.h"
+    extern mraa_lang_func_t* lang_func;
+    // Initialise python threads, this allows use to grab the GIL when we are
+    // required to do so
+    Py_InitializeEx(0);
+    PyEval_InitThreads();
+    // Add mraa_init() to the module initialisation process and set isr function
+    mraa_result_t res = mraa_init();
+    if (res == MRAA_SUCCESS || res == MRAA_ERROR_PLATFORM_ALREADY_INITIALISED) {
+        lang_func->python_isr = &mraa_python_isr;
+    }
+
 %}

--- a/src/python/mraapy.c
+++ b/src/python/mraapy.c
@@ -1,0 +1,95 @@
+/*
+ * Author: Henry Bruce <henry.bruce@intel.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <syslog.h>
+#include <Python.h>
+#include "python/mraapy.h"
+
+
+// In order to call a python object (all python functions are objects) we
+// need to aquire the GIL (Global Interpreter Lock). This may not always be
+// necessary but especially if doing IO (like print()) python will segfault
+// if we do not hold a lock on the GIL
+void
+mraa_python_isr(void (*isr)(void*), void* isr_args)
+{
+
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+    PyObject* arglist;
+    PyObject* ret;
+    arglist = Py_BuildValue("(O)", isr_args);
+    if (arglist == NULL) {
+        syslog(LOG_ERR, "gpio: Py_BuildValue NULL");
+    } else {
+        ret = PyEval_CallObject((PyObject*) isr, arglist);
+        if (ret == NULL) {
+            syslog(LOG_ERR, "gpio: PyEval_CallObject failed");
+            PyObject *pvalue, *ptype, *ptraceback;
+            PyObject *pvalue_pystr, *ptype_pystr, *ptraceback_pystr;
+            char *pvalue_cstr, *ptype_cstr, *ptraceback_cstr;
+            PyErr_Fetch(&pvalue, &ptype, &ptraceback);
+            pvalue_pystr = PyObject_Str(pvalue);
+            ptype_pystr = PyObject_Str(ptype);
+            ptraceback_pystr = PyObject_Str(ptraceback);
+// Python2
+#if PY_VERSION_HEX < 0x03000000
+            pvalue_cstr = PyString_AsString(pvalue_pystr);
+            ptype_cstr = PyString_AsString(ptype_pystr);
+            ptraceback_cstr = PyString_AsString(ptraceback_pystr);
+// Python 3 and up
+#elif PY_VERSION_HEX >= 0x03000000
+            // In Python 3 we need one extra conversion
+            PyObject *pvalue_ustr, *ptype_ustr, *ptraceback_ustr;
+            pvalue_ustr = PyUnicode_AsUTF8String(pvalue_pystr);
+            pvalue_cstr = PyBytes_AsString(pvalue_ustr);
+            ptype_ustr = PyUnicode_AsUTF8String(ptype_pystr);
+            ptype_cstr = PyBytes_AsString(ptype_ustr);
+            ptraceback_ustr = PyUnicode_AsUTF8String(ptraceback_pystr);
+            ptraceback_cstr = PyBytes_AsString(ptraceback_ustr);
+#endif // PY_VERSION_HEX
+            syslog(LOG_ERR, "gpio: the error was %s:%s:%s",
+                   pvalue_cstr,
+                   ptype_cstr,
+                   ptraceback_cstr
+            );
+            Py_XDECREF(pvalue);
+            Py_XDECREF(ptype);
+            Py_XDECREF(ptraceback);
+            Py_XDECREF(pvalue_pystr);
+            Py_XDECREF(ptype_pystr);
+            Py_XDECREF(ptraceback_pystr);
+// Python 3 and up
+#if PY_VERSION_HEX >= 0x03000000
+            Py_XDECREF(pvalue_ustr);
+            Py_XDECREF(ptype_ustr);
+            Py_XDECREF(ptraceback_ustr);
+#endif // PY_VERSION_HEX
+        } else {
+            Py_DECREF(ret);
+        }
+        Py_DECREF(arglist);
+    }
+
+    PyGILState_Release(gilstate);
+}


### PR DESCRIPTION
This PR address #433 for JavaScript and Java, but no Python.  
0041801 is the Java update and is a significant change; look at commit message for details.
@petreeftime, please get Java team to review this update.