### PR TITLE
java: Changed JNI version to 1.6

### DIFF
--- a/src/gpio/gpio.c
+++ b/src/gpio/gpio.c
@@ -246,7 +246,7 @@ static void make_env_key(void)
 {
 
     JNIEnv *jenv;
-    (*globVM)->GetEnv(globVM, (void **)&jenv, JNI_VERSION_1_8);
+    (*globVM)->GetEnv(globVM, (void **)&jenv, JNI_VERSION_1_6);
 
     jclass rcls = (*jenv)->FindClass(jenv, "java/lang/Runnable");
     jmethodID runm = (*jenv)->GetMethodID(jenv, rcls, "run", "()V");
@@ -481,7 +481,7 @@ mraa_gpio_isr(mraa_gpio_context dev, mraa_gpio_edge_t mode, void (*fptr)(void*),
     /* Most UPM sensors use the C API, the global ref must be created here. */
     /* The reason for checking the callback function is internal callbacks. */
     if (fptr == mraa_java_isr_callback) {
-        (*globVM)->GetEnv(globVM, (void **)&jenv, JNI_VERSION_1_8);
+        (*globVM)->GetEnv(globVM, (void **)&jenv, JNI_VERSION_1_6);
         jobject grunnable = (*jenv)->NewGlobalRef(jenv, (jobject) args);
         args = (void *) grunnable;
     }

--- a/src/java/mraajava.i
+++ b/src/java/mraajava.i
@@ -71,7 +71,7 @@ class Spi;
         /* initialize mraa */
         globVM = vm;
         mraa_init();
-        return JNI_VERSION_1_8;
+        return JNI_VERSION_1_6;
     }
 %}
 


### PR DESCRIPTION
This change is needed to compile/run with OpenJDK 7, as well as with
OpenJDK 8.

Signed-off-by: Andrei Vasiliu <andrei.vasiliu@intel.com>