### PR TITLE
uart: Fix for failed malloc

### DIFF
--- a/api/mraa/uart.hpp
+++ b/api/mraa/uart.hpp
@@ -126,12 +126,17 @@ class Uart
      * Read bytes from the device into a String object
      *
      * @param length to read
+     * @throws std::bad_alloc If there is no space left for read.
      * @return string of data
      */
     std::string
     readStr(int length)
     {
         char* data = (char*) malloc(sizeof(char) * length);
+        if (data == NULL) {
+            throw std::bad_alloc();
+        }
+
         int v = mraa_uart_read(m_uart, data, (size_t) length);
         std::string ret(data, v);
         free(data);


### PR DESCRIPTION
Check malloc return in UART read.  Throw if malloc
fails.

Signed-off-by: Noel Eck <noel.eck@intel.com>