### PR TITLE
docs: fixed invalid links in and to imraa docs

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -4,7 +4,7 @@ libmraa uses cmake in order to make compilation relatively painless. CMake runs
 build out of tree so the recommended way is to clone from git and make a `build/`
 directory inside the clone directory.
 
-For building imraa check [building imraa](../master/docs/imraa.md)
+For building imraa check [building imraa](./imraa.md)
 ## Build dependencies
 Not all these are required but if you're unsure of what you're doing this is
 what you'll need:

--- a/docs/imraa.md
+++ b/docs/imraa.md
@@ -6,7 +6,7 @@ MRAA_GENERIC_FIRMATA subplatform to the first process that calls imraa_init
 
 ## Build dependencies
 To build imraa, you'll need to build mraa with -DIMRAA=ON and all the normal
-dependencies for build mraa, see [Building mraa](../master/docs/building.md).
+dependencies for build mraa, see [Building mraa](./building.md).
 You'll also need the following:
 * [dfu-utils-cross](https://github.com/arduino/dfu-utils-cross) or dfu 0.8 (0.9
   does not work well with the 101). Precompiled binaries can be found on


### PR DESCRIPTION
Currently link in building.md pointing to imraa.md and the reverse on in imraa.md are returning HTTP 404 due to pointing to incorrect relative locations. This PR fixes that.