### PR TITLE
Add support for android build

### DIFF
--- a/src/javascript/binding.gyp.cmake
+++ b/src/javascript/binding.gyp.cmake
@@ -3,36 +3,39 @@
     {
       'target_name': 'mraa',
       'sources': [
-@mraa_LIB_SRCS_GYP@
-'src/version.c',
-'src/mraajsJAVASCRIPT_wrap.cxx' ],
+        @mraa_LIB_SRCS_GYP@
+        'src/version.c',
+        'src/mraajsJAVASCRIPT_wrap.cxx'
+      ],
       'include_dirs': [
-@mraa_LIB_INCLUDE_DIRS_GYP@
-                      ],
+        @mraa_LIB_INCLUDE_DIRS_GYP@
+      ],
       'variables': {
-          "v8_version%": "<!(node -e 'console.log(process.versions.v8)' | sed 's/\.//g' | cut -c 1-5)",
-          "arch%": "<!(node -e 'console.log(process.arch)')"
+        "v8_version%": "<!(node -e 'console.log(process.versions.v8)' | sed 's/\.//g' | cut -c 1-5)",
+        "arch%": "<!(node -e 'console.log(process.arch)')"
       },
       'cflags_cc!': [ '-fno-rtti', '-fno-exceptions' ],
       'cflags!': [ '-fno-exceptions' ],
       'conditions' : [
-          [ 'arch=="x64"',
-            { 'defines' : [ 'X86PLAT=ON' ], },
-          ],
-          [ 'arch=="ia32"',
-            { 'defines' : [ 'X86PLAT=ON'], },
-          ],
-          [ 'arch=="arm"',
-            { 'defines' : [ 'ARMPLAT=ON'], },
-          ],
+        ['OS=="android"', {
+          'sources' : [ 'src/glob/glob.c' ],
+          'include_dirs' : [ 'src/glob' ],
+        }],
+        [ 'arch=="x64" or arch=="ia32"', {
+          'defines' : [ 'X86PLAT=ON' ],
+        }],
+        [ 'arch=="arm"', {
+          'defines' : [ 'ARMPLAT=ON'],
+        }],
       ],
-      'defines' : [ 'SWIG',
-                    'SWIGJAVASCRIPT',
-                    'FIRMATA=ON',
-                    'ONEWIRE=ON',
-                    'BUILDING_NODE_EXTENSION=1',
-                    'SWIG_V8_VERSION=0x0<(v8_version)',
-                    'V8_VERSION=0x0<(v8_version)'
+      'defines' : [
+        'SWIG',
+        'SWIGJAVASCRIPT',
+        'FIRMATA=ON',
+        'ONEWIRE=ON',
+        'BUILDING_NODE_EXTENSION=1',
+        'SWIG_V8_VERSION=0x0<(v8_version)',
+        'V8_VERSION=0x0<(v8_version)'
       ]
     }
   ]


### PR DESCRIPTION
Using NPM, this module can be cross-compiled for Android using NDK.
But, when compiling for Android, we need to add glob.c to source files
(as in Android.mk).
Also, re-arranged the layout in binding.gyp for better readability.

Signed-off-by: Robert Chiras <robert.chiras@intel.com>