### PR TITLE
travis-ci: Updates to ensure MRAA builds with clang.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: cpp
 env:
-  - CC=gcc CXX=gcc
-  - CC=clang CXX=clang++
+  - NODE010=true
+  - NODE012=true
   - NODE4=true
   - NODE5=true
-  - NODE012=true
+compiler:
+  - clang
+  - gcc
 install:
   - if [ "${NODE4}" ]; then export CC=gcc-4.8 CXX=g++-4.8; fi
   - sudo add-apt-repository --yes ppa:kalakris/cmake
@@ -14,19 +16,19 @@ install:
   - sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
   - sudo update-java-alternatives -s java-8-oracle
 before_script:
-  - export NODE_ROOT_DIR="/home/travis/.nvm/v0.10.36"
-  - if [ "$CC" = "gcc" ]; then export BUILDJAVA=ON; else export BUILDJAVA=OFF; fi
-  - export JAVA_HOME=/usr/lib/jvm/java-8-oracle
-  - if [ "${NODE4}" ]; then nvm install 4.1; export CC=gcc-4.8; export CXX=g++-4.8; export NODE_ROOT_DIR="/home/travis/.nvm/versions/node/`nvm version`"; fi
-  - if [ "${NODE5}" ]; then nvm install 5; export CC=gcc-4.8; export CXX=g++-4.8; export NODE_ROOT_DIR="/home/travis/.nvm/versions/node/`nvm version`"; fi
-  - if [ "${NODE012}" ]; then nvm install 0.12; export NODE_ROOT_DIR="/home/travis/.nvm/versions/node/`nvm version`"; fi
+  # Turn off JAVA SWIG for clang++, use 4.8 for all g++ builds
+  - if [ "$CC" == "gcc" ]; then export BUILDJAVA=ON; export CC=gcc-4.8; export CXX=g++-4.8; else export BUILDJAVA=OFF; fi
+  - if [ "${NODE012}" ]; then nvm install 0.12; fi
+  - if [ "${NODE4}" ]; then nvm install 4.1; fi
+  - if [ "${NODE5}" ]; then nvm install 5; fi
+  # Handle 0.10 NODE_ROOT_DIR differently than other versions
+  - if [ -z ${NODE010} ]; then export NODE_ROOT_DIR="/home/travis/.nvm/versions/node/`nvm version`"; else export NODE_ROOT_DIR=/home/travis/.nvm/v0.10.36; fi
 script:
-  - mkdir build && cd build && cmake -DBUILDSWIGJAVA=$BUILDJAVA -DNODE_ROOT_DIR:PATH="${NODE_ROOT_DIR}" .. && make && make test
+  - echo "CC=$CC BUILDJAVA=$BUILDJAVA NODE010=$NODE010 NODE012=$NODE012 NODE4=$NODE4 NODE5=$NODE5 NODE_ROOT_DIR=$NODE_ROOT_DIR"
+  - mkdir build && cd build && cmake -DBUILDSWIGJAVA=$BUILDJAVA -DNODE_ROOT_DIR:PATH="${NODE_ROOT_DIR}" -DCMAKE_INSTALL_PREFIX:PATH=../install .. && make install && make test
 addons:
   apt:
     sources:
-      - llvm-toolchain-precise-3.6
       - ubuntu-toolchain-r-test
     packages:
-      - clang-3.6
       - g++-4.8


### PR DESCRIPTION
The MRAA clang build was getting overridden with gcc.
This commit allows MRAA to build with clang and adds nodejs
0.10 to the build matrix.  Note, this means 8 builds
(2 compilers x 4 versions of nodejs).

    * Added compiler directive for clang/gcc.

    * Added build for node010.

    * Added make install to cover the MRAA install.

Signed-off-by: Noel Eck <noel.eck@intel.com>