### PR TITLE
banana_pi.md: fixed header table layout

### DIFF
--- a/docs/banana_pi.md
+++ b/docs/banana_pi.md
@@ -75,6 +75,8 @@ style numbers.
 
 There is also a second 8-pin connector on the Banana Pi, the pins are as follows:
 
+| MRAA Number | Physical Pin | Function  |
+|-------------|--------------|-----------|
 | 27          | P1-19        | 5V VCC    |
 | 28          | P1-20        | 3V3 VCC   |
 | 29          | P1-21        | GPIO(PH5) |


### PR DESCRIPTION
In the second table (second 8-pin connector) wasn't present the table header and
because of that the layout was broken.

Signed-off-by: Bruno Eduardo de Oliveira Meneguele <bmeneguele@gmail.com>