### PR TITLE
mraa.c: Added common function to init io from a description

### DIFF
--- a/api/mraa/aio.hpp
+++ b/api/mraa/aio.hpp
@@ -47,11 +47,24 @@ class Aio
      *
      * @param pin channel number to read ADC inputs
      */
-    Aio(unsigned int pin)
+    Aio(int pin)
     {
         m_aio = mraa_aio_init(pin);
         if (m_aio == NULL) {
             throw std::invalid_argument("Invalid AIO pin specified - do you have an ADC?");
+        }
+    }
+    /**
+     * Aio Constructor, takes a pointer to the AIO context and initialises
+     * the AIO class
+     *
+     * @param void * to an AIO context
+     */
+    Aio(void* aio_context)
+    {
+        m_aio = (mraa_aio_context) aio_context;
+        if (m_aio == NULL) {
+            throw std::invalid_argument("Invalid AIO context");
         }
     }
     /**

--- a/api/mraa/common.h
+++ b/api/mraa/common.h
@@ -293,6 +293,19 @@ mraa_result_t mraa_add_subplatform(mraa_platform_t subplatformtype, const char* 
  */
 mraa_result_t mraa_remove_subplatform(mraa_platform_t subplatformtype);
 
+/**
+ * Create IO using a description in the format:
+ * [io]-[pin]
+ * [io]-[raw]-[pin]
+ * [io]-[raw]-[id]-[pin]
+ * [io]-[raw]-[path]
+ *
+ * @param IO description
+ *
+ * @return void* to IO context or NULL
+ */
+void* mraa_init_io(const char* desc);
+
 #ifdef __cplusplus
 }
 #endif

--- a/api/mraa/common.hpp
+++ b/api/mraa/common.hpp
@@ -309,4 +309,22 @@ removeSubplatform(Platform subplatformtype)
     return (Result) mraa_remove_subplatform((mraa_platform_t) subplatformtype);
 }
 
+/**
+ * Create IO using a description in the format:
+ * [io]-[pin]
+ * [io]-[raw]-[pin]
+ * [io]-[raw]-[id]-[pin]
+ * [io]-[raw]-[path]
+ *
+ * @param IO description
+ *
+ * @return class T initialised using pointer to IO or NULL
+ */
+template <class T>
+inline T*
+initIo(std::string desc)
+{
+    return new T(mraa_init_io(desc.c_str()));
+}
+
 }

--- a/api/mraa/gpio.hpp
+++ b/api/mraa/gpio.hpp
@@ -108,6 +108,19 @@ class Gpio
         }
     }
     /**
+     * Gpio Constructor, takes a pointer to the GPIO context and initialises
+     * the GPIO class
+     *
+     * @param void * to GPIO context
+     */
+    Gpio(void* gpio_context)
+    {
+        m_gpio = (mraa_gpio_context) gpio_context;
+        if (m_gpio == NULL) {
+            throw std::invalid_argument("Invalid GPIO context");
+        }
+    }
+    /**
      * Gpio object destructor, this will only unexport the gpio if we where
      * the owner
      */

--- a/api/mraa/i2c.hpp
+++ b/api/mraa/i2c.hpp
@@ -62,6 +62,18 @@ class I2c
             throw std::invalid_argument("Invalid i2c bus");
         }
     }
+    /**
+     * I2C constructor, takes a pointer to a I2C context and initialises the I2C class
+     *
+     * @param void * to an I2C context
+     */
+    I2c(void* i2c_context)
+    {
+        m_i2c = (mraa_i2c_context) i2c_context;
+        if (m_i2c == NULL) {
+            throw std::invalid_argument("Invalid I2C context");
+        }
+    }
 
     /**
      * Closes the I2c Bus used. This does not guarrantee the bus will not

--- a/api/mraa/pwm.hpp
+++ b/api/mraa/pwm.hpp
@@ -66,6 +66,20 @@ class Pwm
             mraa_pwm_owner(m_pwm, 0);
         }
     }
+
+    /**
+     * Pwm constructor, takes a pointer to the PWM context and
+     * initialises the class
+     *
+     * @param void * to a PWM context
+     */
+    Pwm(void* pwm_context)
+    {
+        m_pwm = (mraa_pwm_context) pwm_context;
+        if (m_pwm == NULL) {
+            throw std::invalid_argument("Invalid PWM context");
+        }
+    }
     /**
      * Pwm destructor
      */

--- a/api/mraa/spi.hpp
+++ b/api/mraa/spi.hpp
@@ -80,6 +80,20 @@ class Spi
     }
 
     /**
+     * Spi Constructor, takes a pointer to a SPI context and initialises
+     * the SPI class
+     *
+     * @param void * to SPI context
+     */
+    Spi(void* spi_context)
+    {
+        m_spi = (mraa_spi_context) spi_context;
+        if (m_spi == NULL) {
+            throw std::invalid_argument("Invalid SPI context");
+        }
+    }
+
+    /**
      * Closes spi bus
      */
     ~Spi()

--- a/api/mraa/uart.hpp
+++ b/api/mraa/uart.hpp
@@ -76,6 +76,20 @@ class Uart
     }
 
     /**
+     * Uart Constructor, takes a pointer to the UART context and initialises
+     * the UART class
+     *
+     * @param void * to a UART context
+     */
+    Uart(void* uart_context)
+    {
+        m_uart = (mraa_uart_context) uart_context;
+
+        if (m_uart == NULL) {
+            throw std::invalid_argument("Invalid UART context");
+        }
+    }
+    /**
      * Uart destructor
      */
     ~Uart()

--- a/src/mraa.i
+++ b/src/mraa.i
@@ -41,6 +41,19 @@
 %include "types.hpp"
 
 %include "common.hpp"
+%template (gpioFromDesc) mraa::initIo<mraa::Gpio>;
+%template (aioFromDesc) mraa::initIo<mraa::Aio>;
+%template (uartFromDesc) mraa::initIo<mraa::Uart>;
+%template (spiFromDesc) mraa::initIo<mraa::Spi>;
+%template (i2cFromDesc) mraa::initIo<mraa::I2c>;
+%template (pwmFromDesc) mraa::initIo<mraa::Pwm>;
+
+%ignore Aio(void* aio_context);
+%ignore Pwm(void* pwm_context);
+%ignore Uart(void* uart_context);
+%ignore Spi(void* spi_context);
+%ignore I2c(void* i2c_context);
+%ignore Gpio(void* gpio_context);
 
 %ignore Gpio::nop(uv_work_t* req);
 %ignore Gpio::v8isr(uv_work_t* req);


### PR DESCRIPTION
mraa_init_io: Added to allow io to be initialised using a description
C++ IO constructors: Added constructors which take a void* to an IO context, used to help wrap the creation of IO using a description.
Aio Constructor: changed the unsigned int constructor to a normal int type, ambiguity errors arose due to the double meaning of unsigned 0 in c++, either the unsigned 0 or a void* to a NULL
mraa.i: Added ignore's for the void* constructors for Aio,Pwm etc., this was because java doesn't know how to handle them, and they also don't need to be in the swig derived languages.

Signed-off-by: Houman Brinjcargorabi <houman.brinjcargorabi@intel.com>