### PR TITLE
PWM: added workaround for Edison's problem with 0% duty

### DIFF
--- a/include/mraa_adv_func.h
+++ b/include/mraa_adv_func.h
@@ -87,7 +87,9 @@ typedef struct {
     mraa_result_t (*pwm_period_replace) (mraa_pwm_context dev, int period);
     float (*pwm_read_replace) (mraa_pwm_context dev);
     mraa_result_t (*pwm_write_replace) (mraa_pwm_context dev, float duty);
+    mraa_result_t (*pwm_write_pre) (mraa_pwm_context dev, float percentage);
     mraa_result_t (*pwm_enable_replace) (mraa_pwm_context dev, int enable);
+    mraa_result_t (*pwm_enable_pre) (mraa_pwm_context dev, int enable);
 
     mraa_result_t (*spi_init_pre) (int bus);
     mraa_result_t (*spi_init_post) (mraa_spi_context spi);

--- a/src/pwm/pwm.c
+++ b/src/pwm/pwm.c
@@ -340,6 +340,13 @@ mraa_pwm_write(mraa_pwm_context dev, float percentage)
         return MRAA_ERROR_INVALID_HANDLE;
     }
 
+    if (IS_FUNC_DEFINED(dev, pwm_write_pre)) {
+        if (dev->advance_func->pwm_write_pre(dev, percentage) != MRAA_SUCCESS) {
+            syslog(LOG_ERR, "mraa_pwm_write (pwm%i): pwm_write_pre failed, see syslog", dev->pin);
+            return MRAA_ERROR_UNSPECIFIED;
+        }
+    }
+
     if (dev->period == -1) {
         if (mraa_pwm_read_period(dev) <= 0)
             return MRAA_ERROR_NO_DATA_AVAILABLE;
@@ -431,6 +438,13 @@ mraa_pwm_enable(mraa_pwm_context dev, int enable)
 
     if (IS_FUNC_DEFINED(dev, pwm_enable_replace)) {
         return dev->advance_func->pwm_enable_replace(dev, enable);
+    }
+
+    if (IS_FUNC_DEFINED(dev, pwm_enable_pre)) {
+        if (dev->advance_func->pwm_enable_pre(dev, enable) != MRAA_SUCCESS) {
+            syslog(LOG_ERR, "mraa_pwm_enable (pwm%i): pwm_enable_pre failed, see syslog", dev->pin);
+            return MRAA_ERROR_UNSPECIFIED;
+        }
     }
 
     char bu[MAX_SIZE];


### PR DESCRIPTION
Proposed fix (rather a proper workaround, which uses board-specific advance functions) for #91.

Two things to mention aside from the logic itself, which should be rather clear from the code:

1. I haven't run clang-format, as there are quite a few existing lines that are longer than .clang-format allows
1. I haven't split adding `pwm_write_pre()` and `pwm_enable_pre()` into the `mraa_adv_func_t` as while they can be viewed as logically separate changes, splitting them would require always applying commits in a certain order (first adv_func_t, then the workaround), which IMHO is more confusing than helpful.

Let me know if you want me to do either of the above.

There's still a thing, which I mentioned in the triaging notes and not related to #91 - when cycling through `write(<non-zero)/enable(0)` pattern (or equivalents directly from the shell - i.e. this is not a mraa thing at all), sporadically instead of disabling the pin, it would set it to something looking like 100%. I'll open a separate issue for debugging this one.

