### PR TITLE
intel_nuc5.c: Fixed incorrect I2C numbering

### DIFF
--- a/src/x86/intel_nuc5.c
+++ b/src/x86/intel_nuc5.c
@@ -126,8 +126,8 @@ mraa_intel_nuc5()
         }
         b->i2c_bus_count++;
         b->i2c_bus[i].bus_id = i2c_num;
-        b->i2c_bus[i].sda = 12 + i;
-        b->i2c_bus[i].scl = 13 + i;
+        b->i2c_bus[i].sda = 12 + (i*2);
+        b->i2c_bus[i].scl = 13 + (i*2);
     }
 
     if (b->i2c_bus_count > 0) {


### PR DESCRIPTION
The pin number was being shifted by one instead of 2, resulting in an incorrect mapping. iteration 0 mapped to pins 12 and 13 iteration 1 mapped to 13 and 14 should have been 14 and 15.

Signed-off-by: Houman Brinjcargorabi <houman.brinjcargorabi@intel.com>