### PR TITLE
intel_edison_fab_c.c: fixed the pins not being freed

### DIFF
--- a/src/x86/intel_edison_fab_c.c
+++ b/src/x86/intel_edison_fab_c.c
@@ -1274,8 +1274,9 @@ mraa_intel_edison_fab_c()
     }
 
     if (mraa_gpio_read_dir(tristate, &tristate_dir) != MRAA_SUCCESS) {
-       free(b->adv_func);
-       goto error;
+        free(b->pins);
+        free(b->adv_func);
+        goto error;
     }
 
     if (tristate_dir != MRAA_GPIO_OUT) {


### PR DESCRIPTION
The pins for the Edison Arduino expansion where not being freed in the case where a tristate was not successful

Signed-off-by: Houman Brinjcargorabi <houman.brinjcargorabi@intel.com>