### PR TITLE
x86.c: fixed typo in Tuchuck board forced enablement

### DIFF
--- a/src/x86/x86.c
+++ b/src/x86/x86.c
@@ -133,7 +133,7 @@ mraa_x86_platform()
     plat = mraa_intel_cherryhills();
     #elif defined(xMRAA_UP)
     plat = mraa_up_board();
-    #elif defined(MRAA_INTEL_GT_TUCHUCK)
+    #elif defined(xMRAA_INTEL_GT_TUCHUCK)
     plat = mraa_gt_tuchuck_board();
     #else
         #error "Not using a valid platform value from mraa_platform_t - cannot compile"


### PR DESCRIPTION
Looks like a typo and it's not going to work without that.