### PR TITLE
cmake: fixed incorrect MRAAPLATFORMFORCE definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ option (INSTALLTOOLS "Install all tools" OFF)
 option (BUILDARCH "Override architecture to build for - override" OFF)
 option (BUILDTESTS "Override the addition of tests" ON)
 
-set (MRAAPLATFORMFORCE "" CACHE STRING "ALL")
+set (MRAAPLATFORMFORCE "ALL" CACHE STRING "Override platform to build for")
 
 if (NOT BUILDSWIG)
   set (BUILDSWIGPYTHON OFF)


### PR DESCRIPTION
This looks like a typo as `ALL` is apparently a default value we want it to have and right now it's a docstring.

It worked all the time due to the fact that during the actual usage we check for "if != 'ALL' <...> else <...>', so it treats everything, which is not a specific platform name as "ALL", but I think it is still worth fixing.