### PR TITLE
iio: mount matrix compliant to IIO core kernel standard

### DIFF
--- a/api/mraa/iio.h
+++ b/api/mraa/iio.h
@@ -121,7 +121,7 @@ mraa_result_t mraa_iio_event_extract_event(struct iio_event_data* event,
                                            int* channel2,
                                            int* different);
 
-mraa_result_t mraa_iio_get_mounting_matrix(mraa_iio_context dev, float mm[9]);
+mraa_result_t mraa_iio_get_mount_matrix(mraa_iio_context dev, const char *sysfs_name, float mm[9]);
 
 mraa_result_t mraa_iio_create_trigger(mraa_iio_context dev, const char* trigger);
 

--- a/src/iio/iio.c
+++ b/src/iio/iio.c
@@ -33,7 +33,6 @@
 #define MAX_SIZE 128
 #define IIO_DEVICE "iio:device"
 #define IIO_SCAN_ELEM "scan_elements"
-#define IIO_MOUNTING_MATRIX "mounting_matrix"
 #define IIO_SLASH_DEV "/dev/" IIO_DEVICE
 #define IIO_SYSFS_DEVICE "/sys/bus/iio/devices/" IIO_DEVICE
 #define IIO_EVENTS "events"
@@ -546,18 +545,18 @@ mraa_iio_event_extract_event(struct iio_event_data* event,
 }
 
 mraa_result_t
-mraa_iio_get_mounting_matrix(mraa_iio_context dev, float mm[9])
+mraa_iio_get_mount_matrix(mraa_iio_context dev, const char *sysfs_name, float mm[9])
 {
     char buf[MAX_SIZE];
     FILE* fp;
     int ret;
 
     memset(buf, 0, MAX_SIZE);
-    snprintf(buf, MAX_SIZE, IIO_SYSFS_DEVICE "%d/" IIO_MOUNTING_MATRIX, dev->num);
+    snprintf(buf, MAX_SIZE, IIO_SYSFS_DEVICE "%d/%s", dev->num, sysfs_name);
     fp = fopen(buf, "r");
     if (fp != NULL) {
-        ret = fscanf(fp, "%f %f %f\n%f %f %f\n%f %f %f\n", &mm[0], &mm[1], &mm[2], &mm[3], &mm[4], &mm[5],
-               &mm[6], &mm[7], &mm[8]);
+        ret = fscanf(fp, "%f, %f, %f; %f, %f, %f; %f, %f, %f\n", &mm[0], &mm[1], &mm[2], &mm[3],
+                     &mm[4], &mm[5],&mm[6], &mm[7], &mm[8]);
         fclose(fp);
         if (ret != 9) {
             return MRAA_ERROR_UNSPECIFIED;


### PR DESCRIPTION
IIO mount matrix is supported in kernel version 4.6.
Change mraa_iio_get_mount_matrix to take in one more parameter
‘mount matrix sysfs entry name’, because different sensor driver
may expose different mount matrix sysfs entry.

Following link explain the mount matrix usage and sysfs entry:
https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-bus-iio

Signed-off-by: Lay, Kuan Loon <kuan.loon.lay@intel.com>