### PR TITLE
gt-tuchuck: fix I2C bus typos in board definition file

### DIFF
--- a/src/x86/intel_gt_tuchuck.c
+++ b/src/x86/intel_gt_tuchuck.c
@@ -69,9 +69,9 @@ mraa_gt_tuchuck_board()
     b->i2c_bus[1].bus_id = 5;
     b->i2c_bus[1].sda = 15;
     b->i2c_bus[1].scl = 17;
-    b->i2c_bus[1].bus_id = 6;
-    b->i2c_bus[1].sda = 19;
-    b->i2c_bus[1].scl = 21;
+    b->i2c_bus[2].bus_id = 6;
+    b->i2c_bus[2].sda = 19;
+    b->i2c_bus[2].scl = 21;
     b->def_i2c_bus = b->i2c_bus[0].bus_id;
 
 #if 0


### PR DESCRIPTION
Signed-off-by: Mihai Tudor Panu <mihai.tudor.panu@intel.com>