### PR TITLE
Mock: added AIO functionality

### DIFF
--- a/docs/mock.md
+++ b/docs/mock.md
@@ -12,17 +12,17 @@ Board configuration
 -------------------
 
 This feature is yet in the experimental mode and not all functionality is available.
-Right now we simulate a single generic board with only GPIO (without ISR) working.
-It also reports having an ADC with 10 (std)/12 (max) bit resolution, but the ADC
-functionality itself is not yet implemented.
+Right now we simulate a single generic board with GPIO (without ISR) and
+an ADC with 10 (std)/12 (max) bit resolution, which returns random values on read.
 
 We plan to develop it further and all [contributions](../CONTRIBUTING.md) are more than welcome.
 
 See the table below for pin layout and features
 
-| MRAA Number | Pin Name |            Notes            |
-|-------------|----------|-----------------------------|
-| 0           | GPIO0    | GPIO pin, no muxing, no ISR |
+| MRAA Number | Pin Name |            Notes                      |
+|-------------|----------|---------------------------------------|
+| 0           | GPIO0    | GPIO pin, no muxing, no ISR           |
+| 1           | ADC0     | AIO pin, returns random value on read |
 
 Building
 --------

--- a/include/mock/mock_board.h
+++ b/include/mock/mock_board.h
@@ -30,7 +30,7 @@ extern "C" {
 
 #include "mraa_internal.h"
 
-#define MRAA_MOCK_PINCOUNT 1
+#define MRAA_MOCK_PINCOUNT 2
 
 mraa_board_t*
 mraa_mock_board();

--- a/include/mraa_adv_func.h
+++ b/include/mraa_adv_func.h
@@ -78,6 +78,7 @@ typedef struct {
     mraa_result_t (*i2c_stop_replace) (mraa_i2c_context dev);
 
     mraa_result_t (*aio_init_internal_replace) (mraa_aio_context dev, int pin);
+    mraa_result_t (*aio_close_replace) (mraa_aio_context dev);
     int (*aio_read_replace) (mraa_aio_context dev);
     mraa_result_t (*aio_get_valid_fp) (mraa_aio_context dev);
     mraa_result_t (*aio_init_pre) (unsigned int aio);

--- a/src/aio/aio.c
+++ b/src/aio/aio.c
@@ -225,13 +225,22 @@ mraa_aio_read_float(mraa_aio_context dev)
 mraa_result_t
 mraa_aio_close(mraa_aio_context dev)
 {
-    if (NULL != dev) {
-        if (dev->adc_in_fp != -1)
-            close(dev->adc_in_fp);
-        free(dev);
+    if (dev == NULL) {
+        syslog(LOG_ERR, "aio: close: context is invalid");
+        return MRAA_ERROR_INVALID_HANDLE;
     }
 
-    return (MRAA_SUCCESS);
+    if (IS_FUNC_DEFINED(dev, aio_close_replace)) {
+        return dev->advance_func->aio_close_replace(dev);
+    }
+
+    if (dev->adc_in_fp != -1) {
+        close(dev->adc_in_fp);
+    }
+
+    free(dev);
+
+    return MRAA_SUCCESS;
 }
 
 mraa_result_t

--- a/src/aio/aio.c
+++ b/src/aio/aio.c
@@ -156,6 +156,11 @@ mraa_aio_init(unsigned int aio)
 int
 mraa_aio_read(mraa_aio_context dev)
 {
+    if (dev == NULL) {
+        syslog(LOG_ERR, "aio: read: context is invalid");
+        return -1;
+    }
+
     if (IS_FUNC_DEFINED(dev, aio_read_replace)) {
         return dev->advance_func->aio_read_replace(dev);
     }

--- a/src/mock/mock_board.c
+++ b/src/mock/mock_board.c
@@ -131,6 +131,29 @@ mraa_mock_gpio_mode_replace(mraa_gpio_context dev, mraa_gpio_mode_t mode)
     return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
 }
 
+mraa_result_t
+mraa_mock_aio_init_internal_replace(mraa_aio_context dev, int pin)
+{
+    dev->channel = pin;
+    return MRAA_SUCCESS;
+}
+
+mraa_result_t
+mraa_mock_aio_close_replace(mraa_aio_context dev)
+{
+    free(dev);
+    return MRAA_SUCCESS;
+}
+
+int
+mraa_mock_aio_read_replace(mraa_aio_context dev)
+{
+    // return some random number between 0 and max value, based on the resolution
+    int max_value = (1 << dev->value_bit) - 1;
+    srand(time(NULL));
+    return rand() % max_value;
+}
+
 mraa_board_t*
 mraa_mock_board()
 {
@@ -142,6 +165,7 @@ mraa_mock_board()
     // General board definitions
     b->platform_name = PLATFORM_NAME;
     b->phy_pin_count = MRAA_MOCK_PINCOUNT;
+    b->gpio_count = 1;
     b->aio_count = 1;
     b->adc_raw = 12;
     b->adc_supported = 10;
@@ -174,6 +198,9 @@ mraa_mock_board()
     b->adv_func->gpio_isr_replace = &mraa_mock_gpio_isr_replace;
     b->adv_func->gpio_isr_exit_replace = &mraa_mock_gpio_isr_exit_replace;
     b->adv_func->gpio_mode_replace = &mraa_mock_gpio_mode_replace;
+    b->adv_func->aio_init_internal_replace = &mraa_mock_aio_init_internal_replace;
+    b->adv_func->aio_close_replace = &mraa_mock_aio_close_replace;
+    b->adv_func->aio_read_replace = &mraa_mock_aio_read_replace;
 
     // Pin definitions
     int pos = 0;
@@ -182,6 +209,12 @@ mraa_mock_board()
     b->pins[pos].capabilites = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
     b->pins[pos].gpio.pinmap = 0;
     b->pins[pos].gpio.mux_total = 0;
+    pos++;
+
+    strncpy(b->pins[pos].name, "ADC0", 8);
+    b->pins[pos].capabilites = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 1, 0 };
+    b->pins[pos].aio.pinmap = 0;
+    b->pins[pos].aio.mux_total = 0;
     pos++;
 
     return b;

--- a/tests/mock/CMakeLists.txt
+++ b/tests/mock/CMakeLists.txt
@@ -8,6 +8,8 @@ add_test (NAME py_gpio_edge COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT
 add_test (NAME py_gpio_isr COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gpio_checks_isr.py)
 add_test (NAME py_gpio_mode COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gpio_checks_mode.py)
 
+add_test (NAME py_aio COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/aio_checks.py)
+
 set_tests_properties(py_general
                      py_platform
                      py_gpio_basic
@@ -16,4 +18,5 @@ set_tests_properties(py_general
                      py_gpio_edge
                      py_gpio_isr
                      py_gpio_mode
+                     py_aio
                      PROPERTIES ENVIRONMENT "PYTHONPATH=${PYTHON_DEFAULT_PYTHONPATH}")

--- a/tests/mock/aio_checks.py
+++ b/tests/mock/aio_checks.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-# Author: Costin Constantin <costin.c.constantin@intel.com>
-# Copyright (c) 2015 Intel Corporation.
-#
-# Contributors: Alex Tereschenko <alext.mkrs@gmail.com>
+# Author: Alex Tereschenko <alext.mkrs@gmail.com>
+# Copyright (c) 2016 Alex Tereschenko.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,23 +25,34 @@
 import mraa as m
 import unittest as u
 
-PLATFORM_PINCOUNT = 2
+MRAA_AIO_TEST_PIN = 0
 PLATFORM_STD_ADC_RES_BITS = 10
 PLATFORM_MAX_ADC_RES_BITS = 12
 
-class PlatformChecks(u.TestCase):
-  def test_platform_pin_count(self):
-    self.assertEqual(m.getPinCount(), PLATFORM_PINCOUNT, "Wrong number of pins reported by platform")
+class AioChecks(u.TestCase):
+  def setUp(self):
+    self.pin = m.Aio(MRAA_AIO_TEST_PIN)
 
-  def test_adc_std_res(self):
-    adc_std_res = m.adcSupportedBits()
-    print("Platform ADC standard resolution is: " + str(adc_std_res) + " bits")
-    self.assertEqual(adc_std_res, PLATFORM_STD_ADC_RES_BITS, "Wrong ADC standard resolution")
+  def tearDown(self):
+    del self.pin
 
-  def test_adc_max_res(self):
-    adc_max_res = m.adcRawBits()
-    print("Platform ADC max. resolution is: " + str(adc_max_res) + " bits")
-    self.assertEqual(adc_max_res, PLATFORM_MAX_ADC_RES_BITS, "Wrong ADC max. resolution")
+  def test_aio_get_bit(self):
+    self.assertEqual(self.pin.getBit(), PLATFORM_STD_ADC_RES_BITS, "Wrong ADC resolution reported")
+
+  def test_aio_set_bit(self):
+    self.pin.setBit(PLATFORM_MAX_ADC_RES_BITS)
+    self.assertEqual(self.pin.getBit(), PLATFORM_MAX_ADC_RES_BITS, "Wrong ADC resolution reported after setBit()")
+
+  def test_aio_read(self):
+    self.assertNotEqual(self.pin.read(), -1, "Error returned when reading ADC value")
+
+  def test_aio_read_float_std_res(self):
+    self.pin.setBit(PLATFORM_STD_ADC_RES_BITS)
+    self.assertNotEqual(self.pin.readFloat(), -1, "Error returned when reading float ADC value at standard resolution")
+
+  def test_aio_read_float_max_res(self):
+    self.pin.setBit(PLATFORM_MAX_ADC_RES_BITS)
+    self.assertNotEqual(self.pin.readFloat(), -1, "Error returned when reading float ADC value at maximum resolution")
 
 if __name__ == "__main__":
   u.main()


### PR DESCRIPTION
Here comes AIO for mraa mock. It could be more elaborated, with additional functions to allow the user to set their own static value to be returned all the time, but I decided to go with a simple random for starters, if anyone needs static, it could be added later.

Commit with `mraa_aio_close()` additions changed enough of the function for a couple of additonal styling fixes (one-line `if` without braces and `return` with value in parentheses - the only place in a whole file we do such things) to become invisible, so I went for that.