### PR TITLE
gpio.h: remove extraneous extern C declaration

### DIFF
--- a/api/mraa/gpio.h
+++ b/api/mraa/gpio.h
@@ -46,9 +46,7 @@ extern "C" {
 
 #if defined(SWIGJAVA) || defined(JAVACALLBACK)
 #include <jni.h>
-extern "C" {
-    void mraa_java_isr_callback(void *args);
-}
+void mraa_java_isr_callback(void *args);
 #endif
 
 /**


### PR DESCRIPTION
Signed-off-by: Jon Trulson <jtrulson@ics.com>