### PR TITLE
uart_ow: convert static const int MRAA_UART_OW_ROMCODE_SIZE to #define

### DIFF
--- a/api/mraa/uart_ow.h
+++ b/api/mraa/uart_ow.h
@@ -64,18 +64,18 @@ extern "C" {
 #include "common.h"
 #include "uart.h"
 
+/* 8 bytes (64 bits) for a device rom code */
+#define MRAA_UART_OW_ROMCODE_SIZE 8
+
 /* for now, we simply use the normal MRAA UART context */
 typedef struct _mraa_uart_ow {
     mraa_uart_context uart;
     /* search state */
-    unsigned char ROM_NO[8]; /* 8 byte (64b) rom code */
+    unsigned char ROM_NO[MRAA_UART_OW_ROMCODE_SIZE]; /* 8 byte (64b) rom code */
     int LastDiscrepancy;
     int LastFamilyDiscrepancy;
     mraa_boolean_t LastDeviceFlag;
 } *mraa_uart_ow_context;
-
-/* 8 bytes (64 bits) for a device rom code */
-static const int MRAA_UART_OW_ROMCODE_SIZE = 8;
 
 /**
  * UART One Wire ROM related Command bytes


### PR DESCRIPTION
This is needed so that this value can be used in all places in C (and
C++) code.  Unlike C++ you can't always use a static const int
variable to declare an array size for example.  Trying to do so will
yield compiler errors.

In addition, during the declaration of the uart_ow_context, replace a
hardcoded '8' with this macro.  Originally, the '8' was hardcoded for
this very reason.

Signed-off-by: Jon Trulson <jtrulson@ics.com>