### PR TITLE
FindNodejs.cmake: added search paths for Ubuntu 16.04

### DIFF
--- a/cmake/modules/FindNodejs.cmake
+++ b/cmake/modules/FindNodejs.cmake
@@ -23,13 +23,16 @@ if (UV_ROOT_DIR)
 endif()
 
 # Now look for node. Flag an error if not found
-find_path (NODE_ROOT_DIR "include/node/node.h" "include/src/node.h"
+find_path (NODE_ROOT_DIR "include/node/node.h" "include/src/node.h" "src/node.h"
   PATHS /usr/include/nodejs /usr/local/include/nodejs /usr/local/include)
 if (NODE_ROOT_DIR)
   add_include_dir(${NODE_ROOT_DIR}/include/src)
+  add_include_dir(${NODE_ROOT_DIR}/src)
   add_include_dir(${NODE_ROOT_DIR}/include/node)
   add_include_dir(${NODE_ROOT_DIR}/include/deps/v8/include)
+  add_include_dir(${NODE_ROOT_DIR}/deps/v8/include)
   add_include_dir(${NODE_ROOT_DIR}/include/deps/uv/include)
+  add_include_dir(${NODE_ROOT_DIR}/deps/uv/include)
 else()
   unset(NODEJS_INCLUDE_DIRS)
   message(ERROR " - node.h not found")


### PR DESCRIPTION
This is to address issue #566. I tried to keep it simple, so we'll just be adding paths to our include dirs list.

It's unlikely that a given system would have Node headers in both those base paths we have there, so I believe this is safe and appropriate solution. If anyone has any other ideas - please comment.