### PR TITLE
add support for IOT2000

### DIFF
--- a/src/x86/x86.c
+++ b/src/x86/x86.c
@@ -51,7 +51,7 @@ mraa_x86_platform()
     FILE* fh = fopen("/sys/devices/virtual/dmi/id/board_name", "r");
     if (fh != NULL) {
         if (getline(&line, &len, fh) != -1) {
-            if (strncmp(line, "GalileoGen2", 11) == 0) {
+            if (strncmp(line, "GalileoGen2", 11) == 0 || strncmp(line, "SIMATIC IOT2000", 15) == 0) {
                 platform_type = MRAA_INTEL_GALILEO_GEN2;
                 plat = mraa_intel_galileo_gen2();
             } else if (strncmp(line, "BODEGA BAY", 10) == 0) {


### PR DESCRIPTION
The Siemens device "SIMATIC IOT2000" is identical to the Intel Galileo
Gen 2 regarding the gpios. So if the board name is "SIMATIC IOT2000"
treat the board as if it is Galileo Gen 2.

Signed-off-by: Sascha Weisenberger <sascha.weisenberger@siemens.com>