### PR TITLE
Add UART functionality to mock

### DIFF
--- a/api/mraa/uart.hpp
+++ b/api/mraa/uart.hpp
@@ -263,7 +263,7 @@ class Uart
      * @return Result of operation
      */
     Result
-    SetNonBlocking(bool nonblock)
+    setNonBlocking(bool nonblock)
     {
         return (Result) mraa_uart_set_non_blocking(m_uart, nonblock);
     }

--- a/api/mraa/uart.hpp
+++ b/api/mraa/uart.hpp
@@ -124,7 +124,7 @@ class Uart
     }
 
     /**
-     * Write bytes in String object to a device
+     * Write bytes in char* buffer to a device
      *
      * @param data buffer pointer
      * @param length maximum size of buffer

--- a/docs/mock.md
+++ b/docs/mock.md
@@ -23,6 +23,8 @@ registers or 5 single-word ones or a mix thereof.
 data items (words or bytes) are calculated from the sent ones using
 `sent_byte (or word) XOR constant` formula.
 See [SPI mock header](../include/mock/mock_board_spi.h#L38-L39) for constant values.
+* Single UART port. All functions are supported, but many are simple stubs. Write
+always succeeds, read returns 'Z' symbol as many times as `read()` requested.
 
 We plan to develop it further and all [contributions](../CONTRIBUTING.md) are more than welcome.
 
@@ -38,6 +40,8 @@ See the table below for pin layout and features
 | 5           | SPI0MOSI | MOSI pin for SPI0 bus                 |
 | 6           | SPI0MISO | MISO pin for SPI0 bus                 |
 | 7           | SPI0SCLK | SCLK pin for SPI0 bus                 |
+| 8           | UART0RX  | RX pin for UART0 port                 |
+| 9           | UART0TX  | TX pin for UART0 port                 |
 
 Building
 --------

--- a/include/mock/mock_board_uart.h
+++ b/include/mock/mock_board_uart.h
@@ -30,10 +30,38 @@ extern "C" {
 
 #include "mraa_internal.h"
 
-#define MRAA_MOCK_PINCOUNT 10
+// ASCII code for "Z", used as a basis for our mock reads
+#define MOCK_UART_DATA_BYTE 0x5A
 
-mraa_board_t*
-mraa_mock_board();
+mraa_result_t
+mraa_mock_uart_set_baudrate_replace(mraa_uart_context dev, unsigned int baud);
+
+mraa_result_t
+mraa_mock_uart_init_raw_replace(mraa_uart_context dev, const char* path);
+
+mraa_result_t
+mraa_mock_uart_flush_replace(mraa_uart_context dev);
+
+mraa_result_t
+mraa_mock_uart_set_flowcontrol_replace(mraa_uart_context dev, mraa_boolean_t xonxoff, mraa_boolean_t rtscts);
+
+mraa_result_t
+mraa_mock_uart_set_mode_replace(mraa_uart_context dev, int bytesize, mraa_uart_parity_t parity, int stopbits);
+
+mraa_result_t
+mraa_mock_uart_set_non_blocking_replace(mraa_uart_context dev, mraa_boolean_t nonblock);
+
+mraa_result_t
+mraa_mock_uart_set_timeout_replace(mraa_uart_context dev, int read, int write, int interchar);
+
+mraa_boolean_t
+mraa_mock_uart_data_available_replace(mraa_uart_context dev, unsigned int millis);
+
+int
+mraa_mock_uart_write_replace(mraa_uart_context dev, const char* buf, size_t len);
+
+int
+mraa_mock_uart_read_replace(mraa_uart_context dev, char* buf, size_t len);
 
 #ifdef __cplusplus
 }

--- a/include/mraa_adv_func.h
+++ b/include/mraa_adv_func.h
@@ -110,4 +110,14 @@ typedef struct {
 
     mraa_result_t (*uart_init_pre) (int index);
     mraa_result_t (*uart_init_post) (mraa_uart_context uart);
+    mraa_result_t (*uart_init_raw_replace) (mraa_uart_context dev, const char* path);
+    mraa_result_t (*uart_flush_replace) (mraa_uart_context dev);
+    mraa_result_t (*uart_set_baudrate_replace) (mraa_uart_context dev, unsigned int baud);
+    mraa_result_t (*uart_set_mode_replace) (mraa_uart_context dev, int bytesize, mraa_uart_parity_t parity, int stopbits);
+    mraa_result_t (*uart_set_flowcontrol_replace) (mraa_uart_context dev, mraa_boolean_t xonxoff, mraa_boolean_t rtscts);
+    mraa_result_t (*uart_set_timeout_replace) (mraa_uart_context dev, int read, int write, int interchar);
+    mraa_result_t (*uart_set_non_blocking_replace) (mraa_uart_context dev, mraa_boolean_t nonblock);
+    int (*uart_read_replace) (mraa_uart_context dev, char* buf, size_t len);
+    int (*uart_write_replace)(mraa_uart_context dev, const char* buf, size_t len);
+    mraa_boolean_t (*uart_data_available_replace) (mraa_uart_context dev, unsigned int millis);
 } mraa_adv_func_t;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,7 @@ set (mraa_LIB_MOCK_SRCS_NOAUTO
   ${PROJECT_SOURCE_DIR}/src/mock/mock_board_aio.c
   ${PROJECT_SOURCE_DIR}/src/mock/mock_board_i2c.c
   ${PROJECT_SOURCE_DIR}/src/mock/mock_board_spi.c
+  ${PROJECT_SOURCE_DIR}/src/mock/mock_board_uart.c
 )
 
 if (JSONPLAT)

--- a/src/mock/mock_board.c
+++ b/src/mock/mock_board.c
@@ -31,8 +31,10 @@
 #include "mock/mock_board_aio.h"
 #include "mock/mock_board_i2c.h"
 #include "mock/mock_board_spi.h"
+#include "mock/mock_board_uart.h"
 
 #define PLATFORM_NAME "MRAA mock platform"
+#define UART_DEV_PATH "dummy"
 
 mraa_board_t*
 mraa_mock_board()
@@ -68,6 +70,12 @@ mraa_mock_board()
     b->pwm_default_period = 0;
     b->pwm_max_period = 0;
     b->pwm_min_period = 0;
+
+    b->uart_dev_count = 1;
+    b->def_uart_dev = 0;
+    b->uart_dev[0].rx = 8;
+    b->uart_dev[0].tx = 9;
+    b->uart_dev[0].device_path = UART_DEV_PATH;
 
     b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_MOCK_PINCOUNT);
     if (b->pins == NULL) {
@@ -117,6 +125,16 @@ mraa_mock_board()
     b->adv_func->spi_write_word_replace = &mraa_mock_spi_write_word_replace;
     b->adv_func->spi_transfer_buf_replace = &mraa_mock_spi_transfer_buf_replace;
     b->adv_func->spi_transfer_buf_word_replace = &mraa_mock_spi_transfer_buf_word_replace;
+    b->adv_func->uart_init_raw_replace = &mraa_mock_uart_init_raw_replace;
+    b->adv_func->uart_set_baudrate_replace = &mraa_mock_uart_set_baudrate_replace;
+    b->adv_func->uart_flush_replace = &mraa_mock_uart_flush_replace;
+    b->adv_func->uart_set_flowcontrol_replace = &mraa_mock_uart_set_flowcontrol_replace;
+    b->adv_func->uart_set_mode_replace = &mraa_mock_uart_set_mode_replace;
+    b->adv_func->uart_set_non_blocking_replace = &mraa_mock_uart_set_non_blocking_replace;
+    b->adv_func->uart_set_timeout_replace = &mraa_mock_uart_set_timeout_replace;
+    b->adv_func->uart_data_available_replace = &mraa_mock_uart_data_available_replace;
+    b->adv_func->uart_write_replace = &mraa_mock_uart_write_replace;
+    b->adv_func->uart_read_replace = &mraa_mock_uart_read_replace;
 
     // Pin definitions
     int pos = 0;
@@ -167,6 +185,20 @@ mraa_mock_board()
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 0 };
     b->pins[pos].spi.mux_total = 0;
     b->pins[pos].spi.pinmap = 0;
+    pos++;
+
+    strncpy(b->pins[pos].name, "UART0RX", 8);
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 1 };
+    b->pins[pos].uart.pinmap = 0;
+    b->pins[pos].uart.parent_id = 0;
+    b->pins[pos].uart.mux_total = 0;
+    pos++;
+
+    strncpy(b->pins[pos].name, "UART0TX", 8);
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 1 };
+    b->pins[pos].uart.pinmap = 0;
+    b->pins[pos].uart.parent_id = 0;
+    b->pins[pos].uart.mux_total = 0;
     pos++;
 
     return b;

--- a/src/mock/mock_board_uart.c
+++ b/src/mock/mock_board_uart.c
@@ -1,0 +1,100 @@
+/*
+ * Author: Alex Tereschenko <alext.mkrs@gmail.com>
+ * Copyright (c) 2016 Alex Tereschenko.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+#include "mock/mock_board_uart.h"
+
+mraa_result_t
+mraa_mock_uart_set_baudrate_replace(mraa_uart_context dev, unsigned int baud)
+{
+    // Limits are taken from uart.c::uint2speed(), they don't matter much anyway
+    if ((baud < 0) || (baud > 4000000)) {
+        syslog(LOG_ERR, "uart%i: set_baudrate: invalid baudrate: %i", dev->index, baud);
+        return MRAA_ERROR_INVALID_PARAMETER;
+    }
+
+    return MRAA_SUCCESS;
+}
+
+mraa_result_t
+mraa_mock_uart_init_raw_replace(mraa_uart_context dev, const char* path)
+{
+    // The only thing we have to do from the original uart_init_raw()
+    return mraa_uart_set_baudrate(dev, 9600);
+}
+
+mraa_result_t
+mraa_mock_uart_flush_replace(mraa_uart_context dev)
+{
+    return MRAA_SUCCESS;
+}
+
+mraa_result_t
+mraa_mock_uart_set_flowcontrol_replace(mraa_uart_context dev, mraa_boolean_t xonxoff, mraa_boolean_t rtscts)
+{
+    return MRAA_SUCCESS;
+}
+
+mraa_result_t
+mraa_mock_uart_set_mode_replace(mraa_uart_context dev, int bytesize, mraa_uart_parity_t parity, int stopbits)
+{
+    return MRAA_SUCCESS;
+}
+
+mraa_result_t
+mraa_mock_uart_set_non_blocking_replace(mraa_uart_context dev, mraa_boolean_t nonblock)
+{
+    return MRAA_SUCCESS;
+}
+
+mraa_result_t
+mraa_mock_uart_set_timeout_replace(mraa_uart_context dev, int read, int write, int interchar)
+{
+    return MRAA_SUCCESS;
+}
+
+mraa_boolean_t
+mraa_mock_uart_data_available_replace(mraa_uart_context dev, unsigned int millis)
+{
+    // Our mock implementation will always have "incoming" data
+    return 1;
+}
+
+int
+mraa_mock_uart_write_replace(mraa_uart_context dev, const char* buf, size_t len)
+{
+    // Our mock implementation always succeeds when sending data
+    return len;
+}
+
+int
+mraa_mock_uart_read_replace(mraa_uart_context dev, char* buf, size_t len)
+{
+    // We'll return MOCK_UART_DATA_BYTE, len times
+    memset(buf, MOCK_UART_DATA_BYTE, len);
+    return len;
+}

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -217,6 +217,15 @@ mraa_uart_init_raw(const char* path)
     }
     dev->path = path;
 
+    if (IS_FUNC_DEFINED(dev, uart_init_raw_replace)) {
+        status = dev->advance_func->uart_init_raw_replace(dev, path);
+        if (status == MRAA_SUCCESS) {
+            return dev;
+        } else {
+            goto init_raw_cleanup;
+        }
+    }
+
     // now open the device
     if ((dev->fd = open(dev->path, O_RDWR)) == -1) {
         syslog(LOG_ERR, "uart: open(%s) failed: %s", path, strerror(errno));
@@ -289,6 +298,10 @@ mraa_uart_flush(mraa_uart_context dev)
         return MRAA_ERROR_INVALID_HANDLE;
     }
 
+    if (IS_FUNC_DEFINED(dev, uart_flush_replace)) {
+        return dev->advance_func->uart_flush_replace(dev);
+    }
+
     if (tcdrain(dev->fd) == -1) {
         return MRAA_ERROR_FEATURE_NOT_SUPPORTED;
     }
@@ -302,6 +315,10 @@ mraa_uart_set_baudrate(mraa_uart_context dev, unsigned int baud)
     if (!dev) {
         syslog(LOG_ERR, "uart: set_baudrate: context is NULL");
         return MRAA_ERROR_INVALID_HANDLE;
+    }
+
+    if (IS_FUNC_DEFINED(dev, uart_set_baudrate_replace)) {
+        return dev->advance_func->uart_set_baudrate_replace(dev, baud);
     }
 
     struct termios termio;
@@ -334,6 +351,10 @@ mraa_uart_set_mode(mraa_uart_context dev, int bytesize, mraa_uart_parity_t parit
     if (!dev) {
         syslog(LOG_ERR, "uart: set_mode: context is NULL");
         return MRAA_ERROR_INVALID_HANDLE;
+    }
+
+    if (IS_FUNC_DEFINED(dev, uart_set_mode_replace)) {
+        return dev->advance_func->uart_set_mode_replace(dev, bytesize, parity, stopbits);
     }
 
     struct termios termio;
@@ -408,6 +429,10 @@ mraa_uart_set_flowcontrol(mraa_uart_context dev, mraa_boolean_t xonxoff, mraa_bo
         return MRAA_ERROR_INVALID_HANDLE;
     }
 
+    if (IS_FUNC_DEFINED(dev, uart_set_flowcontrol_replace)) {
+        return dev->advance_func->uart_set_flowcontrol_replace(dev, xonxoff, rtscts);
+    }
+
     // hardware flow control
     int action = TCIOFF;
     if (xonxoff) {
@@ -448,6 +473,10 @@ mraa_uart_set_timeout(mraa_uart_context dev, int read, int write, int interchar)
         return MRAA_ERROR_INVALID_HANDLE;
     }
 
+    if (IS_FUNC_DEFINED(dev, uart_set_timeout_replace)) {
+        return dev->advance_func->uart_set_timeout_replace(dev, read, write, interchar);
+    }
+
     struct termios termio;
     // get current modes
     if (tcgetattr(dev->fd, &termio)) {
@@ -475,6 +504,10 @@ mraa_uart_set_non_blocking(mraa_uart_context dev, mraa_boolean_t nonblock)
     if (!dev) {
         syslog(LOG_ERR, "uart: non_blocking: context is NULL");
         return MRAA_ERROR_INVALID_HANDLE;
+    }
+
+    if (IS_FUNC_DEFINED(dev, uart_set_non_blocking_replace)) {
+        return dev->advance_func->uart_set_non_blocking_replace(dev, nonblock);
     }
 
     // get current flags
@@ -517,6 +550,10 @@ mraa_uart_read(mraa_uart_context dev, char* buf, size_t len)
         return MRAA_ERROR_INVALID_HANDLE;
     }
 
+    if (IS_FUNC_DEFINED(dev, uart_read_replace)) {
+        return dev->advance_func->uart_read_replace(dev, buf, len);
+    }
+
     if (dev->fd < 0) {
         syslog(LOG_ERR, "uart%i: read: port is not open", dev->index);
         return MRAA_ERROR_INVALID_RESOURCE;
@@ -533,6 +570,10 @@ mraa_uart_write(mraa_uart_context dev, const char* buf, size_t len)
         return MRAA_ERROR_INVALID_HANDLE;
     }
 
+    if (IS_FUNC_DEFINED(dev, uart_write_replace)) {
+        return dev->advance_func->uart_write_replace(dev, buf, len);
+    }
+
     if (dev->fd < 0) {
         syslog(LOG_ERR, "uart%i: write: port is not open", dev->index);
         return MRAA_ERROR_INVALID_RESOURCE;
@@ -547,6 +588,10 @@ mraa_uart_data_available(mraa_uart_context dev, unsigned int millis)
     if (!dev) {
         syslog(LOG_ERR, "uart: data_available: context is NULL");
         return 0;
+    }
+
+    if (IS_FUNC_DEFINED(dev, uart_data_available_replace)) {
+        return dev->advance_func->uart_data_available_replace(dev, millis);
     }
 
     if (dev->fd < 0) {

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -261,7 +261,7 @@ mraa_uart_init_raw(const char* path)
 init_raw_cleanup:
     if (status != MRAA_SUCCESS) {
         if (dev != NULL) {
-            if (dev->fd != -1) {
+            if (dev->fd >= 0) {
                 close(dev->fd);
             }
             free(dev);

--- a/tests/mock/CMakeLists.txt
+++ b/tests/mock/CMakeLists.txt
@@ -30,6 +30,16 @@ add_test (NAME py_spi_checks_write_byte COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${C
 add_test (NAME py_spi_checks_write_word COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/spi_checks_write_word.py)
 add_test (NAME py_spi_checks_write COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/spi_checks_write.py)
 
+add_test (NAME py_uart_checks_set_baudrate COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/uart_checks_set_baudrate.py)
+add_test (NAME py_uart_checks_flush COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/uart_checks_flush.py)
+add_test (NAME py_uart_checks_set_flowcontrol COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/uart_checks_set_flowcontrol.py)
+add_test (NAME py_uart_checks_set_mode COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/uart_checks_set_mode.py)
+add_test (NAME py_uart_checks_set_nonblocking COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/uart_checks_set_nonblocking.py)
+add_test (NAME py_uart_checks_set_timeout COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/uart_checks_set_timeout.py)
+add_test (NAME py_uart_checks_data_available COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/uart_checks_data_available.py)
+add_test (NAME py_uart_checks_write COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/uart_checks_write.py)
+add_test (NAME py_uart_checks_read COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/uart_checks_read.py)
+
 set_tests_properties(py_general
                      py_platform
                      py_gpio_basic
@@ -57,4 +67,13 @@ set_tests_properties(py_general
                      py_spi_checks_write_byte
                      py_spi_checks_write_word
                      py_spi_checks_write
+                     py_uart_checks_set_baudrate
+                     py_uart_checks_flush
+                     py_uart_checks_set_flowcontrol
+                     py_uart_checks_set_mode
+                     py_uart_checks_set_nonblocking
+                     py_uart_checks_set_timeout
+                     py_uart_checks_data_available
+                     py_uart_checks_write
+                     py_uart_checks_read
                      PROPERTIES ENVIRONMENT "PYTHONPATH=${PYTHON_DEFAULT_PYTHONPATH}")

--- a/tests/mock/uart_checks_data_available.py
+++ b/tests/mock/uart_checks_data_available.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-# Author: Costin Constantin <costin.c.constantin@intel.com>
-# Copyright (c) 2015 Intel Corporation.
-#
-# Contributors: Alex Tereschenko <alext.mkrs@gmail.com>
+# Author: Alex Tereschenko <alext.mkrs@gmail.com>
+# Copyright (c) 2016 Alex Tereschenko.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,23 +25,19 @@
 import mraa as m
 import unittest as u
 
-PLATFORM_PINCOUNT = 10
-PLATFORM_STD_ADC_RES_BITS = 10
-PLATFORM_MAX_ADC_RES_BITS = 12
+from uart_checks_shared import *
 
-class PlatformChecks(u.TestCase):
-  def test_platform_pin_count(self):
-    self.assertEqual(m.getPinCount(), PLATFORM_PINCOUNT, "Wrong number of pins reported by platform")
+class UartChecksDataAvailable(u.TestCase):
+  def setUp(self):
+    self.uart = m.Uart(MRAA_UART_DEV_NUM)
 
-  def test_adc_std_res(self):
-    adc_std_res = m.adcSupportedBits()
-    print("Platform ADC standard resolution is: " + str(adc_std_res) + " bits")
-    self.assertEqual(adc_std_res, PLATFORM_STD_ADC_RES_BITS, "Wrong ADC standard resolution")
+  def tearDown(self):
+    del self.uart
 
-  def test_adc_max_res(self):
-    adc_max_res = m.adcRawBits()
-    print("Platform ADC max. resolution is: " + str(adc_max_res) + " bits")
-    self.assertEqual(adc_max_res, PLATFORM_MAX_ADC_RES_BITS, "Wrong ADC max. resolution")
+  def test_uart_data_available(self):
+    self.assertEqual(self.uart.dataAvailable(10),
+                     True,
+                     "Running UART dataAvailable() did not return True")
 
 if __name__ == "__main__":
   u.main()

--- a/tests/mock/uart_checks_flush.py
+++ b/tests/mock/uart_checks_flush.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-# Author: Costin Constantin <costin.c.constantin@intel.com>
-# Copyright (c) 2015 Intel Corporation.
-#
-# Contributors: Alex Tereschenko <alext.mkrs@gmail.com>
+# Author: Alex Tereschenko <alext.mkrs@gmail.com>
+# Copyright (c) 2016 Alex Tereschenko.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,23 +25,19 @@
 import mraa as m
 import unittest as u
 
-PLATFORM_PINCOUNT = 10
-PLATFORM_STD_ADC_RES_BITS = 10
-PLATFORM_MAX_ADC_RES_BITS = 12
+from uart_checks_shared import *
 
-class PlatformChecks(u.TestCase):
-  def test_platform_pin_count(self):
-    self.assertEqual(m.getPinCount(), PLATFORM_PINCOUNT, "Wrong number of pins reported by platform")
+class UartChecksFlush(u.TestCase):
+  def setUp(self):
+    self.uart = m.Uart(MRAA_UART_DEV_NUM)
 
-  def test_adc_std_res(self):
-    adc_std_res = m.adcSupportedBits()
-    print("Platform ADC standard resolution is: " + str(adc_std_res) + " bits")
-    self.assertEqual(adc_std_res, PLATFORM_STD_ADC_RES_BITS, "Wrong ADC standard resolution")
+  def tearDown(self):
+    del self.uart
 
-  def test_adc_max_res(self):
-    adc_max_res = m.adcRawBits()
-    print("Platform ADC max. resolution is: " + str(adc_max_res) + " bits")
-    self.assertEqual(adc_max_res, PLATFORM_MAX_ADC_RES_BITS, "Wrong ADC max. resolution")
+  def test_uart_flush(self):
+    self.assertEqual(self.uart.flush(),
+                     m.SUCCESS,
+                     "Running UART flush() did not return success")
 
 if __name__ == "__main__":
   u.main()

--- a/tests/mock/uart_checks_read.py
+++ b/tests/mock/uart_checks_read.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-# Author: Costin Constantin <costin.c.constantin@intel.com>
-# Copyright (c) 2015 Intel Corporation.
-#
-# Contributors: Alex Tereschenko <alext.mkrs@gmail.com>
+# Author: Alex Tereschenko <alext.mkrs@gmail.com>
+# Copyright (c) 2016 Alex Tereschenko.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,23 +25,28 @@
 import mraa as m
 import unittest as u
 
-PLATFORM_PINCOUNT = 10
-PLATFORM_STD_ADC_RES_BITS = 10
-PLATFORM_MAX_ADC_RES_BITS = 12
+from uart_checks_shared import *
 
-class PlatformChecks(u.TestCase):
-  def test_platform_pin_count(self):
-    self.assertEqual(m.getPinCount(), PLATFORM_PINCOUNT, "Wrong number of pins reported by platform")
+class UartChecksRead(u.TestCase):
+  def setUp(self):
+    self.uart = m.Uart(MRAA_UART_DEV_NUM)
 
-  def test_adc_std_res(self):
-    adc_std_res = m.adcSupportedBits()
-    print("Platform ADC standard resolution is: " + str(adc_std_res) + " bits")
-    self.assertEqual(adc_std_res, PLATFORM_STD_ADC_RES_BITS, "Wrong ADC standard resolution")
+  def tearDown(self):
+    del self.uart
 
-  def test_adc_max_res(self):
-    adc_max_res = m.adcRawBits()
-    print("Platform ADC max. resolution is: " + str(adc_max_res) + " bits")
-    self.assertEqual(adc_max_res, PLATFORM_MAX_ADC_RES_BITS, "Wrong ADC max. resolution")
+  def test_uart_read(self):
+    TEST_DATA_LEN = 10
+    EXPECTED_RESULT = bytearray([MOCK_UART_DATA_BYTE for x in range(TEST_DATA_LEN)])
+    self.assertEqual(self.uart.read(TEST_DATA_LEN),
+                     EXPECTED_RESULT,
+                     "Running UART read(%d) did not return %s" % (TEST_DATA_LEN, repr(EXPECTED_RESULT)))
+
+  def test_uart_readStr(self):
+    TEST_DATA_LEN = 10
+    EXPECTED_RESULT = chr(MOCK_UART_DATA_BYTE) * TEST_DATA_LEN
+    self.assertEqual(self.uart.readStr(TEST_DATA_LEN),
+                     EXPECTED_RESULT,
+                     "Running UART readStr(%d) did not return %s" % (TEST_DATA_LEN, EXPECTED_RESULT))
 
 if __name__ == "__main__":
   u.main()

--- a/tests/mock/uart_checks_set_baudrate.py
+++ b/tests/mock/uart_checks_set_baudrate.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-# Author: Costin Constantin <costin.c.constantin@intel.com>
-# Copyright (c) 2015 Intel Corporation.
-#
-# Contributors: Alex Tereschenko <alext.mkrs@gmail.com>
+# Author: Alex Tereschenko <alext.mkrs@gmail.com>
+# Copyright (c) 2016 Alex Tereschenko.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,23 +25,26 @@
 import mraa as m
 import unittest as u
 
-PLATFORM_PINCOUNT = 10
-PLATFORM_STD_ADC_RES_BITS = 10
-PLATFORM_MAX_ADC_RES_BITS = 12
+from uart_checks_shared import *
 
-class PlatformChecks(u.TestCase):
-  def test_platform_pin_count(self):
-    self.assertEqual(m.getPinCount(), PLATFORM_PINCOUNT, "Wrong number of pins reported by platform")
+class UartChecksSetBaudrate(u.TestCase):
+  def setUp(self):
+    self.uart = m.Uart(MRAA_UART_DEV_NUM)
 
-  def test_adc_std_res(self):
-    adc_std_res = m.adcSupportedBits()
-    print("Platform ADC standard resolution is: " + str(adc_std_res) + " bits")
-    self.assertEqual(adc_std_res, PLATFORM_STD_ADC_RES_BITS, "Wrong ADC standard resolution")
+  def tearDown(self):
+    del self.uart
 
-  def test_adc_max_res(self):
-    adc_max_res = m.adcRawBits()
-    print("Platform ADC max. resolution is: " + str(adc_max_res) + " bits")
-    self.assertEqual(adc_max_res, PLATFORM_MAX_ADC_RES_BITS, "Wrong ADC max. resolution")
+  def test_uart_baudrate_115200(self):
+    TEST_BAUDRATE = 115200
+    self.assertEqual(self.uart.setBaudRate(TEST_BAUDRATE),
+                     m.SUCCESS,
+                     "Setting baudrate to %d did not return success" % TEST_BAUDRATE)
+
+  def test_uart_baudrate_invalid_bigger_than_max(self):
+    TEST_BAUDRATE = 10000000
+    self.assertEqual(self.uart.setBaudRate(TEST_BAUDRATE),
+                     m.ERROR_INVALID_PARAMETER,
+                     "Setting baudrate to %d did not return INVALID_PARAMETER" % TEST_BAUDRATE)
 
 if __name__ == "__main__":
   u.main()

--- a/tests/mock/uart_checks_set_flowcontrol.py
+++ b/tests/mock/uart_checks_set_flowcontrol.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-# Author: Costin Constantin <costin.c.constantin@intel.com>
-# Copyright (c) 2015 Intel Corporation.
-#
-# Contributors: Alex Tereschenko <alext.mkrs@gmail.com>
+# Author: Alex Tereschenko <alext.mkrs@gmail.com>
+# Copyright (c) 2016 Alex Tereschenko.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,23 +25,19 @@
 import mraa as m
 import unittest as u
 
-PLATFORM_PINCOUNT = 10
-PLATFORM_STD_ADC_RES_BITS = 10
-PLATFORM_MAX_ADC_RES_BITS = 12
+from uart_checks_shared import *
 
-class PlatformChecks(u.TestCase):
-  def test_platform_pin_count(self):
-    self.assertEqual(m.getPinCount(), PLATFORM_PINCOUNT, "Wrong number of pins reported by platform")
+class UartChecksSetFlowControl(u.TestCase):
+  def setUp(self):
+    self.uart = m.Uart(MRAA_UART_DEV_NUM)
 
-  def test_adc_std_res(self):
-    adc_std_res = m.adcSupportedBits()
-    print("Platform ADC standard resolution is: " + str(adc_std_res) + " bits")
-    self.assertEqual(adc_std_res, PLATFORM_STD_ADC_RES_BITS, "Wrong ADC standard resolution")
+  def tearDown(self):
+    del self.uart
 
-  def test_adc_max_res(self):
-    adc_max_res = m.adcRawBits()
-    print("Platform ADC max. resolution is: " + str(adc_max_res) + " bits")
-    self.assertEqual(adc_max_res, PLATFORM_MAX_ADC_RES_BITS, "Wrong ADC max. resolution")
+  def test_uart_set_flowcontrol(self):
+    self.assertEqual(self.uart.setFlowcontrol(False, True),
+                     m.SUCCESS,
+                     "Running UART setFlowControl() did not return success")
 
 if __name__ == "__main__":
   u.main()

--- a/tests/mock/uart_checks_set_mode.py
+++ b/tests/mock/uart_checks_set_mode.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-# Author: Costin Constantin <costin.c.constantin@intel.com>
-# Copyright (c) 2015 Intel Corporation.
-#
-# Contributors: Alex Tereschenko <alext.mkrs@gmail.com>
+# Author: Alex Tereschenko <alext.mkrs@gmail.com>
+# Copyright (c) 2016 Alex Tereschenko.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,23 +25,19 @@
 import mraa as m
 import unittest as u
 
-PLATFORM_PINCOUNT = 10
-PLATFORM_STD_ADC_RES_BITS = 10
-PLATFORM_MAX_ADC_RES_BITS = 12
+from uart_checks_shared import *
 
-class PlatformChecks(u.TestCase):
-  def test_platform_pin_count(self):
-    self.assertEqual(m.getPinCount(), PLATFORM_PINCOUNT, "Wrong number of pins reported by platform")
+class UartChecksSetMode(u.TestCase):
+  def setUp(self):
+    self.uart = m.Uart(MRAA_UART_DEV_NUM)
 
-  def test_adc_std_res(self):
-    adc_std_res = m.adcSupportedBits()
-    print("Platform ADC standard resolution is: " + str(adc_std_res) + " bits")
-    self.assertEqual(adc_std_res, PLATFORM_STD_ADC_RES_BITS, "Wrong ADC standard resolution")
+  def tearDown(self):
+    del self.uart
 
-  def test_adc_max_res(self):
-    adc_max_res = m.adcRawBits()
-    print("Platform ADC max. resolution is: " + str(adc_max_res) + " bits")
-    self.assertEqual(adc_max_res, PLATFORM_MAX_ADC_RES_BITS, "Wrong ADC max. resolution")
+  def test_uart_set_mode(self):
+    self.assertEqual(self.uart.setMode(8, m.UART_PARITY_NONE, 1),
+                     m.SUCCESS,
+                     "Running UART setMode() did not return success")
 
 if __name__ == "__main__":
   u.main()

--- a/tests/mock/uart_checks_set_nonblocking.py
+++ b/tests/mock/uart_checks_set_nonblocking.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-# Author: Costin Constantin <costin.c.constantin@intel.com>
-# Copyright (c) 2015 Intel Corporation.
-#
-# Contributors: Alex Tereschenko <alext.mkrs@gmail.com>
+# Author: Alex Tereschenko <alext.mkrs@gmail.com>
+# Copyright (c) 2016 Alex Tereschenko.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,23 +25,19 @@
 import mraa as m
 import unittest as u
 
-PLATFORM_PINCOUNT = 10
-PLATFORM_STD_ADC_RES_BITS = 10
-PLATFORM_MAX_ADC_RES_BITS = 12
+from uart_checks_shared import *
 
-class PlatformChecks(u.TestCase):
-  def test_platform_pin_count(self):
-    self.assertEqual(m.getPinCount(), PLATFORM_PINCOUNT, "Wrong number of pins reported by platform")
+class UartChecksSetNonBlocking(u.TestCase):
+  def setUp(self):
+    self.uart = m.Uart(MRAA_UART_DEV_NUM)
 
-  def test_adc_std_res(self):
-    adc_std_res = m.adcSupportedBits()
-    print("Platform ADC standard resolution is: " + str(adc_std_res) + " bits")
-    self.assertEqual(adc_std_res, PLATFORM_STD_ADC_RES_BITS, "Wrong ADC standard resolution")
+  def tearDown(self):
+    del self.uart
 
-  def test_adc_max_res(self):
-    adc_max_res = m.adcRawBits()
-    print("Platform ADC max. resolution is: " + str(adc_max_res) + " bits")
-    self.assertEqual(adc_max_res, PLATFORM_MAX_ADC_RES_BITS, "Wrong ADC max. resolution")
+  def test_uart_set_nonblocking(self):
+    self.assertEqual(self.uart.setNonBlocking(True),
+                     m.SUCCESS,
+                     "Running UART setNonBlocking() did not return success")
 
 if __name__ == "__main__":
   u.main()

--- a/tests/mock/uart_checks_set_timeout.py
+++ b/tests/mock/uart_checks_set_timeout.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-# Author: Costin Constantin <costin.c.constantin@intel.com>
-# Copyright (c) 2015 Intel Corporation.
-#
-# Contributors: Alex Tereschenko <alext.mkrs@gmail.com>
+# Author: Alex Tereschenko <alext.mkrs@gmail.com>
+# Copyright (c) 2016 Alex Tereschenko.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,23 +25,19 @@
 import mraa as m
 import unittest as u
 
-PLATFORM_PINCOUNT = 10
-PLATFORM_STD_ADC_RES_BITS = 10
-PLATFORM_MAX_ADC_RES_BITS = 12
+from uart_checks_shared import *
 
-class PlatformChecks(u.TestCase):
-  def test_platform_pin_count(self):
-    self.assertEqual(m.getPinCount(), PLATFORM_PINCOUNT, "Wrong number of pins reported by platform")
+class UartChecksSetTimeout(u.TestCase):
+  def setUp(self):
+    self.uart = m.Uart(MRAA_UART_DEV_NUM)
 
-  def test_adc_std_res(self):
-    adc_std_res = m.adcSupportedBits()
-    print("Platform ADC standard resolution is: " + str(adc_std_res) + " bits")
-    self.assertEqual(adc_std_res, PLATFORM_STD_ADC_RES_BITS, "Wrong ADC standard resolution")
+  def tearDown(self):
+    del self.uart
 
-  def test_adc_max_res(self):
-    adc_max_res = m.adcRawBits()
-    print("Platform ADC max. resolution is: " + str(adc_max_res) + " bits")
-    self.assertEqual(adc_max_res, PLATFORM_MAX_ADC_RES_BITS, "Wrong ADC max. resolution")
+  def test_uart_set_timeout(self):
+    self.assertEqual(self.uart.setTimeout(10, 10, 10),
+                     m.SUCCESS,
+                     "Running UART setTimeout() did not return success")
 
 if __name__ == "__main__":
   u.main()

--- a/tests/mock/uart_checks_shared.py
+++ b/tests/mock/uart_checks_shared.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-# Author: Costin Constantin <costin.c.constantin@intel.com>
-# Copyright (c) 2015 Intel Corporation.
-#
-# Contributors: Alex Tereschenko <alext.mkrs@gmail.com>
+# Author: Alex Tereschenko <alext.mkrs@gmail.com>
+# Copyright (c) 2016 Alex Tereschenko.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -24,26 +22,6 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import mraa as m
-import unittest as u
-
-PLATFORM_PINCOUNT = 10
-PLATFORM_STD_ADC_RES_BITS = 10
-PLATFORM_MAX_ADC_RES_BITS = 12
-
-class PlatformChecks(u.TestCase):
-  def test_platform_pin_count(self):
-    self.assertEqual(m.getPinCount(), PLATFORM_PINCOUNT, "Wrong number of pins reported by platform")
-
-  def test_adc_std_res(self):
-    adc_std_res = m.adcSupportedBits()
-    print("Platform ADC standard resolution is: " + str(adc_std_res) + " bits")
-    self.assertEqual(adc_std_res, PLATFORM_STD_ADC_RES_BITS, "Wrong ADC standard resolution")
-
-  def test_adc_max_res(self):
-    adc_max_res = m.adcRawBits()
-    print("Platform ADC max. resolution is: " + str(adc_max_res) + " bits")
-    self.assertEqual(adc_max_res, PLATFORM_MAX_ADC_RES_BITS, "Wrong ADC max. resolution")
-
-if __name__ == "__main__":
-  u.main()
+MRAA_UART_DEV_NUM = 0
+# This one is defined in mock_board_uart.h
+MOCK_UART_DATA_BYTE = 0x5A

--- a/tests/mock/uart_checks_write.py
+++ b/tests/mock/uart_checks_write.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-# Author: Costin Constantin <costin.c.constantin@intel.com>
-# Copyright (c) 2015 Intel Corporation.
-#
-# Contributors: Alex Tereschenko <alext.mkrs@gmail.com>
+# Author: Alex Tereschenko <alext.mkrs@gmail.com>
+# Copyright (c) 2016 Alex Tereschenko.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,23 +25,28 @@
 import mraa as m
 import unittest as u
 
-PLATFORM_PINCOUNT = 10
-PLATFORM_STD_ADC_RES_BITS = 10
-PLATFORM_MAX_ADC_RES_BITS = 12
+from uart_checks_shared import *
 
-class PlatformChecks(u.TestCase):
-  def test_platform_pin_count(self):
-    self.assertEqual(m.getPinCount(), PLATFORM_PINCOUNT, "Wrong number of pins reported by platform")
+class UartChecksWrite(u.TestCase):
+  def setUp(self):
+    self.uart = m.Uart(MRAA_UART_DEV_NUM)
 
-  def test_adc_std_res(self):
-    adc_std_res = m.adcSupportedBits()
-    print("Platform ADC standard resolution is: " + str(adc_std_res) + " bits")
-    self.assertEqual(adc_std_res, PLATFORM_STD_ADC_RES_BITS, "Wrong ADC standard resolution")
+  def tearDown(self):
+    del self.uart
 
-  def test_adc_max_res(self):
-    adc_max_res = m.adcRawBits()
-    print("Platform ADC max. resolution is: " + str(adc_max_res) + " bits")
-    self.assertEqual(adc_max_res, PLATFORM_MAX_ADC_RES_BITS, "Wrong ADC max. resolution")
+  def test_uart_write(self):
+    TEST_DATA_LEN = 10
+    TEST_DATA = bytearray([x for x in range(TEST_DATA_LEN)])
+    self.assertEqual(self.uart.write(TEST_DATA),
+                     TEST_DATA_LEN,
+                     "Running UART write(%s) did not return %d" % (repr(TEST_DATA), TEST_DATA_LEN))
+
+  def test_uart_writeStr(self):
+    TEST_DATA = "Hello"
+    TEST_DATA_LEN = len(TEST_DATA)
+    self.assertEqual(self.uart.writeStr(TEST_DATA),
+                     TEST_DATA_LEN,
+                     "Running UART writeStr(%s) did not return %d" % (TEST_DATA, TEST_DATA_LEN))
 
 if __name__ == "__main__":
   u.main()


### PR DESCRIPTION
This is the last piece I was planning for the mock functionality, rounding up the feature set to include pretty much everything mraa can do (exceptions are PWM and GPIO ISRs, which I believe irrelevant for mock).

As usual, while doing that I've spotted a couple of unrelated small bugs/inconsistencies, which I piggyback as separate commits.

Of particular interest may be the one, which corrects the ` setNonBlocking()` function name - it was inconsistently spelled as `SetNonBlocking()`. Formally that's an API change, so that might bring some harm to existing code. Let's see if you think we can get it in right now or not. If not, then we could either leave both of spelling versions for some time or rework my mock functionality patch to use the incorrect version and only release the correction the next time we feel it's okay to go.