### PR TITLE
UartOW C++ interface fixes

### DIFF
--- a/api/mraa/uart_ow.hpp
+++ b/api/mraa/uart_ow.hpp
@@ -233,7 +233,7 @@ class UartOW
     mraa::Result
     command(uint8_t command, std::string id)
     {
-        if (id.empty() == 0)
+        if (id.empty())
             return (mraa::Result) mraa_uart_ow_command(m_uart, command, NULL);
         else {
             if (id.size() != 8) {
@@ -241,7 +241,7 @@ class UartOW
                 throw std::invalid_argument(std::string(__FUNCTION__) +
                                             ": id must be 8 bytes only");
             }
-            return (mraa::Result) mraa_uart_ow_command(m_uart, command, (uint8_t*) id.c_str());
+            return (mraa::Result) mraa_uart_ow_command(m_uart, command, (uint8_t*) id.data());
         }
     }
 
@@ -268,7 +268,7 @@ class UartOW
     uint8_t
     crc8(std::string buffer)
     {
-        return mraa_uart_ow_crc8((uint8_t*) buffer.c_str(), buffer.size());
+        return mraa_uart_ow_crc8((uint8_t*) buffer.data(), buffer.size());
     }
 
   private:

--- a/examples/c++/UartOW.cpp
+++ b/examples/c++/UartOW.cpp
@@ -59,7 +59,7 @@ main(int argc, char** argv)
     while (!id.empty()) {
         // hack so we don't need to cast each element of the romcode
         // for printf purposes
-        uint8_t* ptr = (uint8_t*) id.c_str();
+        uint8_t* ptr = (uint8_t*) id.data();
 
         // The first byte (0) is the device type (family) code.
         // The last byte (7) is the rom code CRC value.  The


### PR DESCRIPTION
    uart_ow.hpp: Correct a logic bug, and 2  questionable uses of c_str()
    
    The command() function had a logic error that caused a command to be
    broadcast to all devices on the DS OW bus when a proper ID was
    specified.  This should only be done when NO ID is specified.
    
    This fixes UPM issue #502.
