### PR TITLE
Added platform support for phyBOARD-Wega

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ ARM
 * [Raspberry Pi](../master/docs/raspberry_pi.md)
 * [Banana Pi](../master/docs/banana_pi.md)
 * [Beaglebone Black](../master/docs/beaglebone.md)
+* [phyBOARD-Wega](../master/docs/phyboard-wega.md)
 
 USB
 ---

--- a/api/mraa/types.h
+++ b/api/mraa/types.h
@@ -51,6 +51,7 @@ typedef enum {
     MRAA_INTEL_CHERRYHILLS = 11,     /**< The Intel Braswell Cherryhills */
     MRAA_UP = 12,                    /**< The UP Board */
     MRAA_INTEL_GT_TUCHUCK = 13,      /**< The Intel GT Tuchuck Board */
+    MRAA_PHYBOARD_WEGA = 14,        /**< The phyBOARD-Wega */
 
     // USB platform extenders start at 256
     MRAA_FTDI_FT4222 = 256,         /**< FTDI FT4222 USB to i2c bridge */

--- a/api/mraa/types.hpp
+++ b/api/mraa/types.hpp
@@ -52,6 +52,7 @@ typedef enum {
     INTEL_CHERRYHILLS = 11,    /**< The Intel Braswell Cherryhills */
     INTEL_UP = 12,             /**< The UP Board */
     INTEL_GT_TUCHUCK = 13,     /**< The Intel GT Board */
+    PHYBOARD_WEGA = 14,        /**< The phyBOARD-Wega */
 
     FTDI_FT4222 = 256,         /**< FTDI FT4222 USB to i2c bridge */
 

--- a/docs/index.java.md
+++ b/docs/index.java.md
@@ -45,6 +45,7 @@ Specific platform information for supported platforms is documented here:
 - @ref rasppi
 - @ref bananapi
 - @ref beaglebone
+- @ref phyboard-wega
 - @ref nuc5
 - @ref up
 - @ref grossetete

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ Specific platform information for supported platforms is documented here:
 - @ref rasppi
 - @ref bananapi
 - @ref beaglebone
+- @ref phyboard-wega
 - @ref nuc5
 - @ref up
 - @ref grossetete

--- a/docs/phyboard-wega.md
+++ b/docs/phyboard-wega.md
@@ -1,0 +1,235 @@
+phyBOARD-Wega    {#phyboard-wega}
+=============
+
+The phyBOARD-Wega for phyCORA-AM335x is a low-cost, feature-rich software 
+development platform supporting the Texas Instruments AM335x microcontroller.
+
+Moreover, due to the numerous standard interfaces the phyBOARD-Wega AM335x can
+serve as bedrock for your application. At the core of the phyBOARD-Wega is the
+PCL-051/phyCORE-AM335x System on Module (SOM) in a direct solder form factor,
+containing the prozessor, DRAM, NAND Flash, power regulation, supervision,
+transceivers, and other core functions required to support the AM335x 
+processor. Surrounding the SOM is the PBA-CD-02/phyBOARD-Wega carrier board,
+adding power input, buttons, connectors, signal breakout, and Ethernet 
+connectivity amongst other things.
+
+There are (for example) some expansion boards available for the phyBOARD-Wega:
+- Power Module (PEB-POW-01)
+- Evaluation Board (PEB-EVAL-01)
+- HDMI Adapter (PEB-AV-01)
+
+For further information and instruction please visit:
+www.phytec.de/produkt/system-on-modules/single-board-computer/phyboard-wega
+
+
+Interface notes
+---------------
+
+**SPI**
+/* TODO */
+
+**I2C**
+/* TODO */
+
+**UART**
+Uart0 can be used over pins on X69 connector or serial port on Evaluation Board.
+The other Uarts not have been tested yet. This is a small TODO for future.
+
+
+Pin Assignment of X69 Expansion Connector
+-----------------------------------------
+
+| Physical Pin | Signal Name         | Type | SL    | Description             |
+|--------------|---------------------|------|-------|-------------------------|
+| 1            | VCC3V3              | OUT  | 3.3 V | 3.3V power supply       |
+| 2            | VCC5V               | OUT  | 5.0 V | 5V power supply         |
+| 3            | VDIG1_1P8V          | OUT  | 1.8 V | 1.8V power supply       |
+|              |                     |      |       |      (max. 300mA)       |
+| 4            | GND                 | -    | -     | Ground                  |
+| 5            | X_SPIO_CS0          | OUT  | 3.3 V | SPI 0 chip select 0     |
+| 6            | X_SPIO_MOSI         | OUT  | 3.3 V | SPI 0 master output /   |
+|              |                     |      |       |       slave input       |
+| 7            | X_SPIO_MISO         | IN   | 3.3 V | SPI 0 master input /    |
+|              |                     |      |       |       slave output      |
+| 8            | X_SPIO_CLK          | OUT  | 3.3 V | SPI 0 clock output      |
+| 9            | GND                 | -    | -     | Ground                  |
+| 10           | X_UART0_RXD         | IN   | 3.3 V | UART 0 receive data     |
+|              |                     |      |       |      (std. debug iface) |
+| 11           | X_I2C0_SDA          | I/O  | 3.3 V | I2C0 Data               |
+| 12           | X_UART0_TXD         | OUT  | 3.3 V | UART 0 transmit data    |
+|              |                     |      |       |      (std. debug iface) |
+| 13           | X_I2C0_SCL          | I/O  | 3.3 V | I2C0 Clock              |
+| 14           | GND                 | -    | -     | Ground                  |
+| 15           | X_JTAG_TMS          | IN   | 3.3 V | JTAG Chain Test         |
+|              |                     |      |       |      Mode Select signal |
+| 16           | X_nJTAG_TRST        | IN   | 3.3 V | JTAG Chain Test Reset   |
+| 17           | X_JTAG_TDI          | IN   | 3.3 V | JTAG Chain Test         |
+|              |                     |      |       |      Data Input         |
+| 18           | X_JTAG_TDO          | OUT  | 3.3 V | JTAG Chain Test         |
+|              |                     |      |       |      Data Output        |
+| 19           | GND                 | -    | -     | Ground                  |
+| 20           | X_JTAG_TCK          | IN   | 3.3 V | JTAG Chain Test         |
+|              |                     |      |       |      Clock signal       |
+| 21           | X_USB_DP_EXP        | I/O  | 3.3 V | USB data plus           |
+|              |                     |      |       |      (for USB0 or USB1) |
+| 22           | X_USB_DM_EXP        | I/O  | 3.3 V | USB data minus          |
+|              |                     |      |       |      (for USB0 or USB1) |
+| 23           | nRESET_OUT          | OUT  | 3.3 V | Reset                   |
+| 24           | GND                 | -    | -     | Ground                  |
+| 25           | X_MMC2_CMD          | I/O  | 3.3 V | MMC command             |
+| 26           | X_MMC2_DATO         | I/O  | 3.3 V | MMC data 0              |
+| 27           | X_MMC2_CLK          | I/O  | 3.3 V | MMC clock               |
+| 28           | X_MMC2_DAT1         | I/O  | 3.3 V | MMC data 1              |
+| 29           | GND                 | -    | -     | Ground                  |
+| 30           | X_MMC2_DAT2         | I/O  | 3.3 V | MMC data 2              |
+| 31           | X_UART2_RX_GPIO3_9  | I/O  | 3.3 V | UART 2 receive data     |
+|              |                     |      |       | or GPIO3_9              |
+| 32           | X_MMC2_DAT3         | I/O  | 3.3 V | MMC data 3              |
+| 33           | X_UART2_TX_GPIO3_10 | I/O  | 3.3 V | UART 2 transmit data    |
+|              |                     |      |       | or GPIO3_10             |
+| 34           | GND                 | -    | -     | Ground                  |
+| 35           | X_UART3_RX_GPIO2_18 | I/O  | 3.3 V | UART 3 receive data     |
+|              |                     |      |       | or GPIO2_18             |
+| 36           | X_UART3_TX_GPIO2_19 | I/O  | 3.3 V | UART 3 transmit data    |
+|              |                     |      |       |        or GPIO2_19      |
+| 37           | X_INTR1_GPIO0_20    | I/O  | 3.3 V | Interrupt 1 or GPIO0_20 |
+| 38           | X_GPIO0_7           | I/O  | 3.3 V | GPIO0_7                 |
+| 39           | X_AM335_EXT_WAKEUP  | IN   | 3.3 V | External wakeup         |
+| 40           | X_INT_RTCn          | OUT  | 3.3 V | Interrupt from the RTC  |
+| 41           | GND                 | -    | -     | Ground                  |
+| 42           | X_GPIO3_7_nPMOD_PW  | I/O  | 3.3 V | GPIO3_7; Caution! Also  |
+|              | RFAIL               |      |       | connected to power fail |
+|              |                     |      |       | signal through R415.    |
+| 43           | nRESET_IN           | IN   | 3.3 V | Push-button reset       |
+| 44           | X_GPIO1_31          | I/O  | 3.3 V | GPIO1_31                |
+| 45           | X_AM335_NMIn        | IN   | 3.3 V | AM335x                  |
+|              |                     |      |       | non-maskable interrupt  |
+| 46           | GND                 | -    | -     | Ground                  |
+| 47           | X_AIN4              | IN   | 1.8 V | Analog input 4          |
+| 48           | X_AIN5              | IN   | 1.8 V | Analog input 5          |
+| 49           | X_AIN6              | IN   | 1.8 V | Analog input 6          |
+| 50           | X_AIN7              | IN   | 1.8 V | Analog input 7          |
+| 51           | GND                 | -    | -     | Ground                  |
+| 52           | X_GPIO_CKSYNC       | I/O  | 3.3 V | GPIO Clock              |
+|              |                     |      |       | Synchronization         |
+| 53           | X_USB_ID_EXP        | IN   | 1.8 V | USB port identification |
+|              |                     |      |       |      (for USB0 or USB1) |
+| 54           | USB_VBUS_EXP        | OUT  | 5.0 V | USB bus voltage         |
+|              |                     |      |       |      (for USB0 or USB1) |
+| 55           | X_USB1_CE           | OUT  | 3.3 V | USB 1 charger enable    |
+| 56           | GND                 | -    | -     | Ground                  |
+| 57           | VCC_BL              | OUT  | NS    | Backlight power supply  |
+| 58           | X_BP_POWER          | IN   | 5.0 V | Power On for Power      |
+|              |                     |      |       | Management IC for AM335x|
+| 59           | GND                 | -    | -     | Ground                  |
+| 60           | VCC5V_IN            | IN   | 5.0 V | 5 V input supply voltage|
+
+
+Pin Assignment of X70 A/V Connector
+-----------------------------------
+
+| Physical Pin | Signal Name         | Type | SL    | Description             |
+|--------------|---------------------|------|-------|-------------------------|
+| 1            | GND                 | -    | -     | Ground                  |
+| 2            | X_LCD_D21           | OUT  | 3.3 V | LCD D21                 |
+| 3            | X_LCD_D18           | OUT  | 3.3 V | LCD D18                 |
+| 4            | X_LCD_D16           | OUT  | 3.3 V | LCD D16                 |
+| 5            | X_LCD_D0            | OUT  | 3.3 V | LCD D0                  |
+| 6            | GND                 | -    | -     | Ground                  |
+| 7            | X_LCD_D1            | OUT  | 3.3 V | LCD D1                  |
+| 8            | X_LCD_D2            | OUT  | 3.3 V | LCD D2                  |
+| 9            | X_LCD_D3            | OUT  | 3.3 V | LCD D3                  |
+| 10           | X_LCD_D4            | OUT  | 3.3 V | LCD D4                  |
+| 11           | GND                 | -    | -     | Ground                  |
+| 12           | X_LCD_D22           | OUT  | 3.3 V | LCD D22                 |
+| 13           | X_LCD_D19           | OUT  | 3.3 V | LCD D19                 |
+| 14           | X_LCD_D5            | OUT  | 3.3 V | LCD D5                  |
+| 15           | X_LCD_D6            | OUT  | 3.3 V | LCD D6                  |
+| 16           | GND                 | -    | -     | Ground                  |
+| 17           | X_LCD_D7            | OUT  | 3.3 V | LCD D7                  |
+| 18           | X_LCD_D8            | OUT  | 3.3 V | LCD D8                  |
+| 19           | X_LCD_D9            | OUT  | 3.3 V | LCD D9                  |
+| 20           | X_LCD_D10           | OUT  | 3.3 V | LCD D10                 |
+| 21           | GND                 | -    | -     | Ground                  |
+| 22           | X_LCD_D23           | OUT  | 3.3 V | LCD D23                 |
+| 23           | X_LCD_D20           | OUT  | 3.3 V | LCD D20                 |
+| 24           | X_LCD_D17           | OUT  | 3.3 V | LCD D17                 |
+| 25           | X_LCD_D11           | OUT  | 3.3 V | LCD D11                 |
+| 26           | GND                 | -    | -     | Ground                  |
+| 27           | X_LCD_D12           | OUT  | 3.3 V | LCD D12                 |
+| 28           | X_LCD_D13           | OUT  | 3.3 V | LCD D13                 |
+| 29           | X_LCD_D14           | OUT  | 3.3 V | LCD D14                 |
+| 30           | X_LCD_D15           | OUT  | 3.3 V | LCD D15                 |
+| 31           | GND                 | -    | -     | Ground                  |
+| 32           | X_LCD_PCLK          | OUT  | 3.3 V | LCD Pixel Clock         |
+| 33           | X_LCD_BIAS_EN       | OUT  | 3.3 V | LCD BIAS                |
+| 34           | X_LCD_HSYNC         | OUT  | 3.3 V | LCD Horizontal          |
+|              |                     |      |       |     Synchronization     |
+| 35           | X_LCD_VSYNC         | OUT  | 3.3 V | LCD Vertical            |
+|              |                     |      |       |     Synchronisation     |
+| 36           | GND                 | -    | -     | Ground                  |
+| 37           | GND                 | -    | -     | Ground                  |
+| 38           | X_PWM1_OUT          | OUT  | 3.3 V | Pulse Width Modulation  |
+| 39           | VCC_BL              | OUT  | NS    | Backlight power supply  |
+| 40           | VCC5V               | OUT  | 5.0 V | 5 V power supply        |
+
+
+Pin Assignment of X71 A/V Connector
+-----------------------------------
+
+| Physical Pin | Signal Name         | Type | SL    | Description             |
+|--------------|---------------------|------|-------|-------------------------|
+| 1            | X_I2S_CLK           | I/O  | 3.3 V | I2S Clock               |
+| 2            | X_I2S_FRM           | I/O  | 3.3 V | I2S Frame               |
+| 3            | X_I2S_ADC           | I/O  | 3.3 V | I2S Analog-Digital      |
+|              |                     |      |       |  converter (microphone) |
+| 4            | X_I2S_DAC           | I/O  | 3.3 V | I2S Digital-Analog      |
+|              |                     |      |       |  converter (speaker)    |
+| 5            | X_AV_INT_GPIO1_30   | I/O  | 3.3 V | A/V interrupt; GPIO1_30 |
+| 6            | nUSB1_OC_GPIO3_19 or| I/O  | 3.3 V | GPIO3_19 or McASP0      |
+|          | X_MCASP0_AHCLKX_GPIO3_21|      |       | high frequency clock    |
+| 7            | GND                 | -    | -     | Ground                  |
+| 8            | nRESET_OUT          | OUT  | 3.3 V | Reset                   |
+| 9            | TS_X+               | IN   | 1.8 V | Touch X+                |
+| 10           | TS_X-               | IN   | 1.8 V | Touch X-                |
+| 11           | TS_Y+               | IN   | 1.8 V | Touch Y+                |
+| 12           | TS_Y-               | IN   | 1.8 V | Touch Y-                |
+| 13           | VCC3V3              | OUT  | 3.3 V | 3.3 V power supply      |
+| 14           | GND                 | -    | -     | Ground                  |
+| 15           | X_I2C0_SCL          | I/O  | 3.3 V | I2C Clock               |
+| 16           | X_I2C0_SDA          | I/O  | 3.3 V | I2C Data                |
+
+Jumper J77 connects either signal X_MCASP0_AHCLKX_GPIO3_21 or signal
+nUSB1_OC_GPIO3_19 to pin 6 of X71.
+The following table shows the available configurations:
+
+A/V Jumper configuration J77
+----------------------------
+
+| J77 | Description              |
+|-----|--------------------------|
+| 1+2 | X_MCASP0_AHCLKX_GPIO3_21 |
+| 2+3 | nUSB1_OC_GPIO3_19        |
+
+Caution:    If J77 is set to 2+3 , J78 also has to be set to 2+3 !
+
+
+GPIO - Pin-mapping (with installed expansion board)
+---------------------------------------------------
+
+| Physical Pin | Pin-Name      | Pin-Map / Sysfs GPIO | Def. usage | Connector|
+|--------------|---------------|----------------------|------------|----------|
+| 31           | X_GPIO3_9     | 105                  | OUT  LED3  | X69      |
+| 33           | X_GPIO3_10    | 106                  | IN   S3    | X69      |
+| 35           | X_GPIO2_18    |  82 (buisy)          | OUT  LED1  | X69      |
+| 36           | X_GPIO2_19    |  83                  | OUT  LED2  | X69      |
+| 37           | X_GPIO0_20    |  20 (buisy)          | IN   S1    | X69      |
+| 38           | X_GPIO0_7     |   7                  | IN   S2    | X69      |
+| 42           | X_GPIO3_7     | 103                  | IN         | X69      |
+| 44           | X_GPIO1_31    |  63                  | IN         | X69      |
+|--------------|---------------|----------------------|------------|----------|
+| 5 (105)      | X_GPIO1_30    |  62                  | IN         | X71      |
+| 6 (106)      | X_GPIO3_19 or | 115                  | IN         | X71      |
+|              | X_GPIO3_21    | 117                  | IN         | X71      |
+
+Info: (buisy) means, that it is used by kernel driver!

--- a/docs/phyboard-wega.md
+++ b/docs/phyboard-wega.md
@@ -1,13 +1,13 @@
 phyBOARD-Wega    {#phyboard-wega}
 =============
 
-The phyBOARD-Wega for phyCORA-AM335x is a low-cost, feature-rich software 
+The phyBOARD-Wega for phyCORE-AM335x is a low-cost, feature-rich software 
 development platform supporting the Texas Instruments AM335x microcontroller.
 
 Moreover, due to the numerous standard interfaces the phyBOARD-Wega AM335x can
 serve as bedrock for your application. At the core of the phyBOARD-Wega is the
 PCL-051/phyCORE-AM335x System on Module (SOM) in a direct solder form factor,
-containing the prozessor, DRAM, NAND Flash, power regulation, supervision,
+containing the processor, DRAM, NAND Flash, power regulation, supervision,
 transceivers, and other core functions required to support the AM335x 
 processor. Surrounding the SOM is the PBA-CD-02/phyBOARD-Wega carrier board,
 adding power input, buttons, connectors, signal breakout, and Ethernet 
@@ -26,7 +26,9 @@ Interface notes
 ---------------
 
 **SPI**
-/* TODO */
+Spi0 can be used over pins on X69 connector. There are no more spi-devices.
+Independent of the given index in mraa_phyboard_spi_init_pre() function,
+it will be always initialized spi0.
 
 **I2C**
 /* TODO */
@@ -211,7 +213,7 @@ A/V Jumper configuration J77
 | 1+2 | X_MCASP0_AHCLKX_GPIO3_21 |
 | 2+3 | nUSB1_OC_GPIO3_19        |
 
-Caution:    If J77 is set to 2+3 , J78 also has to be set to 2+3 !
+Caution: If J77 is set to 2+3 , J78 also has to be set to 2+3 !
 
 
 GPIO - Pin-mapping (with installed expansion board)
@@ -221,9 +223,9 @@ GPIO - Pin-mapping (with installed expansion board)
 |--------------|---------------|----------------------|------------|----------|
 | 31           | X_GPIO3_9     | 105                  | OUT  LED3  | X69      |
 | 33           | X_GPIO3_10    | 106                  | IN   S3    | X69      |
-| 35           | X_GPIO2_18    |  82 (buisy)          | OUT  LED1  | X69      |
+| 35           | X_GPIO2_18    |  82 (busy)           | OUT  LED1  | X69      |
 | 36           | X_GPIO2_19    |  83                  | OUT  LED2  | X69      |
-| 37           | X_GPIO0_20    |  20 (buisy)          | IN   S1    | X69      |
+| 37           | X_GPIO0_20    |  20 (busy)           | IN   S1    | X69      |
 | 38           | X_GPIO0_7     |   7                  | IN   S2    | X69      |
 | 42           | X_GPIO3_7     | 103                  | IN         | X69      |
 | 44           | X_GPIO1_31    |  63                  | IN         | X69      |
@@ -232,4 +234,4 @@ GPIO - Pin-mapping (with installed expansion board)
 | 6 (106)      | X_GPIO3_19 or | 115                  | IN         | X71      |
 |              | X_GPIO3_21    | 117                  | IN         | X71      |
 
-Info: (buisy) means, that it is used by kernel driver!
+Info: (busy) means, that it is used by kernel driver!

--- a/include/arm/am335x.h
+++ b/include/arm/am335x.h
@@ -1,5 +1,6 @@
 /*
  * Author: Norbert Wesp <nwesp@phytec.de>
+ * Author: Stefan Müller-Klieser <S.Mueller-Klieser@phytec.de>
  * Copyright (c) 2016 Phytec Messtechnik GmbH.
  *
  * Based on src/arm/beaglebone.c

--- a/include/arm/am335x.h
+++ b/include/arm/am335x.h
@@ -1,0 +1,85 @@
+/*
+ * Author: Norbert Wesp <nwesp@phytec.de>
+ * Copyright (c) 2016 Phytec Messtechnik GmbH.
+ *
+ * Based on src/arm/beaglebone.c
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <mraa/types.h>
+
+#include "common.h"
+
+#define SYSFS_CLASS_PWM "/sys/class/pwm/"
+#define SYSFS_CLASS_MMC "/sys/class/mmc_host/"
+
+#define MMAP_PATH "/dev/mem"
+#define MAX_SIZE 64
+
+#define AM335X_GPIO0_BASE 0x44e07000
+#define AM335X_GPIO1_BASE 0x4804c000
+#define AM335X_GPIO2_BASE 0x481AC000
+#define AM335X_GPIO3_BASE 0x481AE000
+#define AM335X_GPIO_SIZE (4 * 1024)
+#define AM335X_IN 0x138
+#define AM335X_CLR 0x190
+#define AM335X_SET 0x194
+
+/**
+ * Writes 'value' to gpio_context 'dev'
+ *
+ * @return mraa_result_t indicating success of actions.
+ */
+mraa_result_t mraa_am335x_mmap_write(mraa_gpio_context dev, int value);
+
+/**
+ * Unsetup register of mmap_gpio[]
+ *
+ * @return static mraa_result_t indicating success of actions.
+ */
+static mraa_result_t mraa_am335x_mmap_unsetup();
+
+/**
+ * Read from gpio_context 'dev'
+ *
+ * @return int result indicating success of actions.
+ */
+int mraa_am335x_mmap_read(mraa_gpio_context dev);
+
+/**
+ * Disables gpio_context 'dev' in case of 'en' or mmap'ing gpio_context 'dev'
+ *
+ * @return mraa_result_t indicating success of actions.
+ */
+mraa_result_t mraa_am335x_mmap_setup(mraa_gpio_context dev, mraa_boolean_t en);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/arm/phyboard.h
+++ b/include/arm/phyboard.h
@@ -1,5 +1,6 @@
 /*
  * Author: Norbert Wesp <nwesp@phytec.de>
+ * Author: Stefan Müller-Klieser <S.Mueller-Klieser@phytec.de>
  * Copyright (c) 2016 Phytec Messtechnik GmbH.
  *
  * Based on include/arm/beaglebone.h

--- a/include/arm/phyboard.h
+++ b/include/arm/phyboard.h
@@ -1,0 +1,41 @@
+/*
+ * Author: Norbert Wesp <nwesp@phytec.de>
+ * Copyright (c) 2016 Phytec Messtechnik GmbH.
+ *
+ * Based on include/arm/beaglebone.h
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "mraa_internal.h"
+
+#define MRAA_PHYBOARD_WEGA_PINCOUNT 117
+
+mraa_board_t * mraa_phyboard();
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,7 @@ set (mraa_LIB_ARM_SRCS_NOAUTO
   ${PROJECT_SOURCE_DIR}/src/arm/96boards.c
   ${PROJECT_SOURCE_DIR}/src/arm/raspberry_pi.c
   ${PROJECT_SOURCE_DIR}/src/arm/beaglebone.c
+  ${PROJECT_SOURCE_DIR}/src/arm/phyboard.c
   ${PROJECT_SOURCE_DIR}/src/arm/banana.c
 )
 

--- a/src/arm/am335x.c
+++ b/src/arm/am335x.c
@@ -1,5 +1,6 @@
 /*
  * Author: Norbert Wesp <nwesp@phytec.de>
+ * Author: Stefan Müller-Klieser <S.Mueller-Klieser@phytec.de>
  * Copyright (c) 2016 Phytec Messtechnik GmbH.
  *
  * Based on src/arm/beaglebone.c
@@ -76,7 +77,6 @@ mraa_am335x_mmap_read(mraa_gpio_context dev)
 {
     uint32_t value = *(volatile uint32_t*) (mmap_gpio[dev->pin / 32] + AM335X_IN);
     if (value & (uint32_t)(1 << (dev->pin % 32))) {
-
         return 1;
     }
 

--- a/src/arm/am335x.c
+++ b/src/arm/am335x.c
@@ -1,0 +1,160 @@
+/*
+ * Author: Norbert Wesp <nwesp@phytec.de>
+ * Copyright (c) 2016 Phytec Messtechnik GmbH.
+ *
+ * Based on src/arm/beaglebone.c
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <mraa/types.h>
+
+#include "common.h"
+#include "arm/am335x.h"
+
+// MMAP
+static uint8_t* mmap_gpio[4] = { NULL, NULL, NULL, NULL };
+static int mmap_fd = 0;
+static unsigned int mmap_count = 0;
+
+mraa_result_t
+mraa_am335x_mmap_write(mraa_gpio_context dev, int value)
+{
+    if (value) {
+        *(volatile uint32_t*) (mmap_gpio[dev->pin / 32] + AM335X_SET) = (uint32_t)(1 << (dev->pin % 32));
+    } else {
+        *(volatile uint32_t*) (mmap_gpio[dev->pin / 32] + AM335X_CLR) = (uint32_t)(1 << (dev->pin % 32));
+    }
+
+    return MRAA_SUCCESS;
+}
+
+static mraa_result_t
+mraa_am335x_mmap_unsetup()
+{
+    if (mmap_gpio[0] == NULL) {
+        syslog(LOG_ERR, "am335x mmap: null register cant unsetup");
+
+        return MRAA_ERROR_INVALID_RESOURCE;
+    }
+    munmap(mmap_gpio[0], AM335X_GPIO_SIZE);
+    mmap_gpio[0] = NULL;
+    munmap(mmap_gpio[1], AM335X_GPIO_SIZE);
+    mmap_gpio[1] = NULL;
+    munmap(mmap_gpio[2], AM335X_GPIO_SIZE);
+    mmap_gpio[2] = NULL;
+    munmap(mmap_gpio[3], AM335X_GPIO_SIZE);
+    mmap_gpio[3] = NULL;
+    if (close(mmap_fd) != 0) {
+        return MRAA_ERROR_INVALID_RESOURCE;
+    }
+    return MRAA_SUCCESS;
+}
+
+int
+mraa_am335x_mmap_read(mraa_gpio_context dev)
+{
+    uint32_t value = *(volatile uint32_t*) (mmap_gpio[dev->pin / 32] + AM335X_IN);
+    if (value & (uint32_t)(1 << (dev->pin % 32))) {
+
+        return 1;
+    }
+
+    return 0;
+}
+
+mraa_result_t
+mraa_am335x_mmap_setup(mraa_gpio_context dev, mraa_boolean_t en)
+{
+    if (dev == NULL) {
+        syslog(LOG_ERR, "am335x mmap: context not valid");
+        return MRAA_ERROR_INVALID_HANDLE;
+    }
+
+    if (en == 0) {
+        if (dev->mmap_write == NULL && dev->mmap_read == NULL) {
+            syslog(LOG_ERR, "am335x mmap: can't disable disabled mmap gpio");
+            return MRAA_ERROR_INVALID_PARAMETER;
+        }
+        dev->mmap_write = NULL;
+        dev->mmap_read = NULL;
+        mmap_count--;
+        if (mmap_count == 0) {
+            return mraa_am335x_mmap_unsetup();
+        }
+        return MRAA_SUCCESS;
+    }
+
+    if (dev->mmap_write != NULL && dev->mmap_read != NULL) {
+        syslog(LOG_ERR, "am335x mmap: can't enable enabled mmap gpio");
+        return MRAA_ERROR_INVALID_PARAMETER;
+    }
+
+    // Might need to make some elements of this thread safe.
+    // For example only allow one thread to enter the following block
+    // to prevent mmap'ing twice.
+    if (mmap_gpio[0] == NULL) {
+        if ((mmap_fd = open(MMAP_PATH, O_RDWR)) < 0) {
+            syslog(LOG_ERR, "am335x map: unable to open resource file");
+            return MRAA_ERROR_INVALID_HANDLE;
+        }
+
+        mmap_gpio[0] = (uint8_t*) mmap(NULL, AM335X_GPIO_SIZE, PROT_READ | PROT_WRITE,
+                                       MAP_FILE | MAP_SHARED, mmap_fd, AM335X_GPIO0_BASE);
+        if (mmap_gpio[0] == MAP_FAILED) {
+            syslog(LOG_ERR, "am335x mmap: failed to mmap");
+            mmap_gpio[0] = NULL;
+            close(mmap_fd);
+            return MRAA_ERROR_NO_RESOURCES;
+        }
+        mmap_gpio[1] = (uint8_t*) mmap(NULL, AM335X_GPIO_SIZE, PROT_READ | PROT_WRITE,
+                                       MAP_FILE | MAP_SHARED, mmap_fd, AM335X_GPIO1_BASE);
+        if (mmap_gpio[1] == MAP_FAILED) {
+            syslog(LOG_ERR, "am335x mmap: failed to mmap");
+            mmap_gpio[1] = NULL;
+            close(mmap_fd);
+            return MRAA_ERROR_NO_RESOURCES;
+        }
+        mmap_gpio[2] = (uint8_t*) mmap(NULL, AM335X_GPIO_SIZE, PROT_READ | PROT_WRITE,
+                                       MAP_FILE | MAP_SHARED, mmap_fd, AM335X_GPIO2_BASE);
+        if (mmap_gpio[2] == MAP_FAILED) {
+            syslog(LOG_ERR, "am335x mmap: failed to mmap");
+            mmap_gpio[2] = NULL;
+            close(mmap_fd);
+            return MRAA_ERROR_NO_RESOURCES;
+        }
+        mmap_gpio[3] = (uint8_t*) mmap(NULL, AM335X_GPIO_SIZE, PROT_READ | PROT_WRITE,
+                                       MAP_FILE | MAP_SHARED, mmap_fd, AM335X_GPIO3_BASE);
+        if (mmap_gpio[3] == MAP_FAILED) {
+            syslog(LOG_ERR, "am335x mmap: failed to mmap");
+            mmap_gpio[3] = NULL;
+            close(mmap_fd);
+            return MRAA_ERROR_NO_RESOURCES;
+        }
+    }
+    dev->mmap_write = &mraa_am335x_mmap_write;
+    dev->mmap_read = &mraa_am335x_mmap_read;
+    mmap_count++;
+
+    return MRAA_SUCCESS;
+}

--- a/src/arm/arm.c
+++ b/src/arm/arm.c
@@ -29,6 +29,7 @@
 #include "arm/96boards.h"
 #include "arm/banana.h"
 #include "arm/beaglebone.h"
+#include "arm/phyboard.h"
 #include "arm/raspberry_pi.h"
 #include "mraa_internal.h"
 
@@ -49,7 +50,11 @@ mraa_arm_platform()
                 } else if (strstr(line, "BCM2709")) {
                     platform_type = MRAA_RASPBERRY_PI;
                 } else if (strstr(line, "Generic AM33XX")) {
-                    platform_type = MRAA_BEAGLEBONE;
+                    if(mraa_file_contains("/sys/firmware/devicetree/base/model", "phyBOARD-WEGA")) {
+                        platform_type = MRAA_PHYBOARD_WEGA;
+                    } else {
+                        platform_type = MRAA_BEAGLEBONE;
+                    }
                 } else if (strstr(line, "HiKey Development Board")) {
                     platform_type = MRAA_96BOARDS;
                 } else if (strstr(line, "s900")) {
@@ -90,6 +95,9 @@ mraa_arm_platform()
             break;
         case MRAA_BEAGLEBONE:
             plat = mraa_beaglebone();
+            break;
+        case MRAA_PHYBOARD_WEGA:
+            plat = mraa_phyboard();
             break;
         case MRAA_BANANA:
             plat = mraa_banana();

--- a/src/arm/phyboard.c
+++ b/src/arm/phyboard.c
@@ -1,0 +1,672 @@
+/*
+ * Author: Norbert Wesp <nwesp@phytec.de>
+ * Copyright (c) 2016 Phytec Messtechnik GmbH.
+ *
+ * Based on src/arm/beaglebone.c
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <mraa/types.h>
+
+#include "common.h"
+#include "arm/phyboard.h"
+#include "arm/am335x.h"
+
+#define PLATFORM_NAME_PHYBOARD_WEGA "phyBOARD-Wega"
+
+mraa_result_t
+mraa_phyboard_uart_init_pre(int index)
+{
+    char devpath[MAX_SIZE];
+
+    sprintf(devpath, "/dev/ttyO%u", index);
+    if (!mraa_file_exist(devpath)) {
+        syslog(LOG_ERR, "uart: Device not initialized");
+    } else {
+        plat->uart_dev[index].device_path = devpath;
+        return MRAA_SUCCESS;
+    }
+
+    return MRAA_ERROR_NO_RESOURCES;
+}
+
+/* NOT DONE / TESTED YET */
+mraa_result_t
+mraa_phyboard_spi_init_pre(int index)
+{
+    mraa_result_t ret = MRAA_ERROR_NO_RESOURCES;
+    char devpath[MAX_SIZE];
+    int deviceindex = 0;
+
+    if ((index == 0) && mraa_link_targets("/sys/class/spidev/spidev1.0", "48030000"))
+        deviceindex = 1;
+    if (deviceindex == 0)
+        deviceindex = 1;
+
+    sprintf(devpath, "/dev/spidev%u.0", deviceindex);
+    if (mraa_file_exist(devpath)) {
+        plat->spi_bus[index].bus_id = deviceindex;
+        ret = MRAA_SUCCESS;
+
+    } else {
+        syslog(LOG_NOTICE, "spi: Device not initialized");
+    }
+    return ret;
+}
+
+/* NOT DONE / TESTED YET */
+mraa_result_t
+mraa_phyboard_i2c_init_pre(unsigned int bus)
+{
+    mraa_result_t ret = MRAA_ERROR_NO_RESOURCES;
+    char devpath[MAX_SIZE];
+
+    sprintf(devpath, "/dev/i2c-%u", plat->i2c_bus[bus].bus_id);
+    if (!mraa_file_exist(devpath)) {
+        syslog(LOG_INFO, "i2c: %s doesn't exist ", devpath);
+        syslog(LOG_ERR, "i2c: Device not initialized");
+
+        return ret;
+    }
+    return MRAA_SUCCESS;
+}
+
+/* NOT DONE / TESTED YET */
+mraa_pwm_context
+mraa_phyboard_pwm_init_replace(int pin)
+{
+    char devpath[MAX_SIZE];
+
+    if (plat == NULL) {
+        syslog(LOG_ERR, "pwm: Platform Not Initialised");
+        return NULL;
+    }
+    if (plat->pins[pin].capabilities.pwm != 1) {
+        syslog(LOG_ERR, "pwm: pin not capable of pwm");
+        return NULL;
+    }
+    if (!mraa_file_exist(SYSFS_CLASS_PWM "pwmchip0")) {
+        syslog(LOG_ERR, "pwm: pwmchip0 not found");
+        return NULL;
+    }
+
+    sprintf(devpath, SYSFS_CLASS_PWM "pwm%u", plat->pins[pin].pwm.pinmap);
+    if (!mraa_file_exist(devpath)) {
+        FILE* fh;
+        fh = fopen(SYSFS_CLASS_PWM "export", "w");
+        if (fh == NULL) {
+            syslog(LOG_ERR, "pwm: Failed to open /sys/class/pwm/export for writing, check access "
+                            "rights for user");
+            return NULL;
+        }
+        if (fprintf(fh, "%d", plat->pins[pin].pwm.pinmap) < 0) {
+            syslog(LOG_ERR, "pwm: Failed to write to sysfs-pwm-export");
+        }
+        fclose(fh);
+    }
+
+    if (mraa_file_exist(devpath)) {
+        mraa_pwm_context dev = (mraa_pwm_context) calloc(1, sizeof(struct _pwm));
+        if (dev == NULL)
+            return NULL;
+        dev->duty_fp = -1;
+        dev->chipid = -1;
+        dev->pin = plat->pins[pin].pwm.pinmap;
+        dev->period = -1;
+        return dev;
+    } else
+        syslog(LOG_ERR, "pwm: pin not initialized");
+    return NULL;
+}
+
+
+mraa_board_t*
+mraa_phyboard()
+{
+    unsigned int uart2_enabled = 0;
+    unsigned int uart3_enabled = 0;
+
+    if (mraa_file_exist("/sys/class/tty/ttyO2"))
+        uart2_enabled = 1;
+    else
+        uart2_enabled = 0;
+
+    if (mraa_file_exist("/sys/class/tty/ttyO3"))
+        uart3_enabled = 1;
+    else
+        uart3_enabled = 0;
+
+    mraa_board_t* b = (mraa_board_t*) calloc(1, sizeof(mraa_board_t));
+    if (b == NULL)
+        return NULL;
+    b->platform_name = PLATFORM_NAME_PHYBOARD_WEGA;
+    b->phy_pin_count = MRAA_PHYBOARD_WEGA_PINCOUNT;
+
+    if (b->platform_name == NULL) {
+        goto error;
+    }
+
+    b->aio_count = 4;
+    b->adc_raw = 1;
+    b->adc_supported = 1;
+
+    b->pwm_default_period = 500;
+    b->pwm_max_period = 2147483;
+    b->pwm_min_period = 1;
+
+    b->pins = (mraa_pininfo_t*) calloc(b->phy_pin_count,sizeof(mraa_pininfo_t));
+    if (b->pins == NULL) {
+        goto error;
+    }
+
+    b->adv_func = (mraa_adv_func_t*) calloc(1, sizeof(mraa_adv_func_t));
+    if (b->adv_func == NULL) {
+        free(b->pins);
+        goto error;
+    }
+
+    b->adv_func->uart_init_pre = &mraa_phyboard_uart_init_pre;
+    b->adv_func->spi_init_pre = &mraa_phyboard_spi_init_pre;
+    b->adv_func->i2c_init_pre = &mraa_phyboard_i2c_init_pre;
+    b->adv_func->pwm_init_replace = &mraa_phyboard_pwm_init_replace;
+
+    strncpy(b->pins[0].name, "INVALID", MRAA_PIN_NAME_SIZE);
+    b->pins[0].capabilities = (mraa_pincapabilities_t){ 0, 0, 0, 0, 0, 0, 0, 0 };
+
+    // X69 connector
+    strncpy(b->pins[1].name, "VCC3V3", MRAA_PIN_NAME_SIZE);
+    b->pins[1].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[2].name, "VCC5V", MRAA_PIN_NAME_SIZE);
+    b->pins[2].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[3].name, "VDIG1_1P8V", MRAA_PIN_NAME_SIZE);
+    b->pins[3].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[4].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[4].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[5].name, "X_SPIO_CS0", MRAA_PIN_NAME_SIZE);
+    b->pins[5].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 0 };
+    b->pins[5].spi.mux_total = 0;
+
+    strncpy(b->pins[6].name, "X_SPIO_MOSI", MRAA_PIN_NAME_SIZE);
+    b->pins[6].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 0 };
+    b->pins[6].spi.mux_total = 0;
+
+    strncpy(b->pins[7].name, "X_SPIO_MISO", MRAA_PIN_NAME_SIZE);
+    b->pins[7].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 0 };
+    b->pins[7].spi.mux_total = 0;
+
+    strncpy(b->pins[8].name, "X_SPIO_CLK", MRAA_PIN_NAME_SIZE);
+    b->pins[8].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 0 };
+    b->pins[8].spi.mux_total = 0;
+
+    strncpy(b->pins[9].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[9].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[10].name, "X_UART0_RXD", MRAA_PIN_NAME_SIZE);
+    b->pins[10].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 1 };
+    b->pins[10].uart.mux_total = 0;
+
+    strncpy(b->pins[11].name, "X_I2C0_SDA", MRAA_PIN_NAME_SIZE);
+    b->pins[11].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 };
+    b->pins[11].i2c.mux_total = 0;
+
+    strncpy(b->pins[12].name, "X_UART0_TXD", MRAA_PIN_NAME_SIZE);
+    b->pins[12].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 1 };
+    b->pins[12].uart.mux_total = 0;
+
+    strncpy(b->pins[13].name, "X_I2C0_SCL", MRAA_PIN_NAME_SIZE);
+    b->pins[13].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 };
+    b->pins[13].i2c.mux_total = 0;
+
+    strncpy(b->pins[14].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[14].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[15].name, "X_JTAG_TMS", MRAA_PIN_NAME_SIZE);
+    b->pins[15].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[16].name, "X_nJTAG_TRST", MRAA_PIN_NAME_SIZE);
+    b->pins[16].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[17].name, "X_JTAG_TDI", MRAA_PIN_NAME_SIZE);
+    b->pins[17].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[18].name, "X_JTAG_TDO", MRAA_PIN_NAME_SIZE);
+    b->pins[18].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[19].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[19].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[20].name, "X_JTAG_TCK", MRAA_PIN_NAME_SIZE);
+    b->pins[20].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[21].name, "X_USB_DP_EXP", MRAA_PIN_NAME_SIZE);
+    b->pins[21].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[22].name, "X_USB_DM_EXP", MRAA_PIN_NAME_SIZE);
+    b->pins[22].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[23].name, "nRESET_OUT", MRAA_PIN_NAME_SIZE);
+    b->pins[32].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[24].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[24].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[25].name, "X_MMC2_CMD", MRAA_PIN_NAME_SIZE);
+    b->pins[25].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[26].name, "X_MMC2_DATO", MRAA_PIN_NAME_SIZE);
+    b->pins[26].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[27].name, "X_MMC2_CLK", MRAA_PIN_NAME_SIZE);
+    b->pins[27].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[28].name, "X_MMC2_DAT1", MRAA_PIN_NAME_SIZE);
+    b->pins[28].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[29].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[29].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[30].name, "X_MMC2_DAT2", MRAA_PIN_NAME_SIZE);
+    b->pins[30].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    /* PIN-Number "31" with name "X_UART2_RX_GPIO3_9" */
+    if (uart2_enabled == 1) {
+        strncpy(b->pins[31].name, "X_UART2_RX", MRAA_PIN_NAME_SIZE);
+        b->pins[31].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    } else {
+        strncpy(b->pins[31].name, "X_GPIO3_9", MRAA_PIN_NAME_SIZE);
+        b->pins[31].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    }
+    b->pins[31].gpio.pinmap = (3*32 + 9);
+    b->pins[31].gpio.parent_id = 0;
+    b->pins[31].gpio.mux_total = 0;
+    b->pins[31].uart.mux_total = 0;
+
+    strncpy(b->pins[32].name, "X_MMC2_DAT3", MRAA_PIN_NAME_SIZE);
+    b->pins[32].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    /* PIN-Number "33" with name "X_UART2_TX_GPIO3_10" */
+    if (uart2_enabled == 1) {
+        strncpy(b->pins[33].name, "X_UART2_TX", MRAA_PIN_NAME_SIZE);
+        b->pins[33].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    } else {
+        strncpy(b->pins[33].name, "X_GPIO3_10", MRAA_PIN_NAME_SIZE);
+        b->pins[33].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    }
+    b->pins[33].gpio.pinmap = (3*32 + 10);
+    b->pins[33].gpio.parent_id = 0;
+    b->pins[33].gpio.mux_total = 0;
+    b->pins[33].uart.mux_total = 0;
+    
+    strncpy(b->pins[34].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[34].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    /* PIN-Number "35" with name "X_UART3_RX_GPIO2_18" */
+    if (uart3_enabled == 1) {
+        strncpy(b->pins[35].name, "X_UART3_RX", MRAA_PIN_NAME_SIZE);
+        b->pins[35].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    } else {
+        strncpy(b->pins[35].name, "X_GPIO2_18", MRAA_PIN_NAME_SIZE);
+        b->pins[35].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    }
+    b->pins[35].gpio.pinmap = (2*32 + 18);
+    b->pins[35].gpio.parent_id = 0;
+    b->pins[35].gpio.mux_total = 0;
+    b->pins[35].uart.mux_total = 0;
+
+    /*  PIN-Number "36" with name "X_UART3_TX_GPIO2_19" */
+    if (uart3_enabled == 1) {
+        strncpy(b->pins[36].name, "X_UART3_TX", MRAA_PIN_NAME_SIZE);
+        b->pins[36].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    } else {
+        strncpy(b->pins[36].name, "X_GPIO2_19", MRAA_PIN_NAME_SIZE);
+        b->pins[36].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    }
+    b->pins[36].gpio.pinmap = (2*32 + 19);
+    b->pins[36].gpio.parent_id = 0;
+    b->pins[36].gpio.mux_total = 0;
+    b->pins[36].uart.mux_total = 0;
+
+    /* PIN-Number "37" with name "X_INTR1_GPIO0_20" */
+    strncpy(b->pins[37].name, "X_GPIO0_20", MRAA_PIN_NAME_SIZE);
+    b->pins[37].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
+    b->pins[37].gpio.pinmap = (0*32 + 20);
+    b->pins[37].gpio.parent_id = 0;
+    b->pins[37].gpio.mux_total = 0;
+
+    strncpy(b->pins[38].name, "X_GPIO0_7", MRAA_PIN_NAME_SIZE);
+    b->pins[38].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
+    b->pins[38].gpio.pinmap = (0*32 + 7);
+    b->pins[38].gpio.parent_id = 0;
+    b->pins[38].gpio.mux_total = 0;
+
+    strncpy(b->pins[39].name, "X_AM335_EXT_WAKEUP", MRAA_PIN_NAME_SIZE);
+    b->pins[39].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[40].name, "X_INT_RTCn", MRAA_PIN_NAME_SIZE);
+    b->pins[40].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[41].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[41].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    /* PIN-Number "42" with name "X_GPIO3_7_nPMOD_PW RFAIL" */
+    strncpy(b->pins[42].name, "X_GPIO3_7", MRAA_PIN_NAME_SIZE);
+    b->pins[42].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
+    b->pins[42].gpio.pinmap = (3*32 + 7);
+    b->pins[42].gpio.parent_id = 0;
+    b->pins[42].gpio.mux_total = 0;
+
+    strncpy(b->pins[43].name, "nRESET_IN", MRAA_PIN_NAME_SIZE);
+    b->pins[43].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[44].name, "X_GPIO1_31", MRAA_PIN_NAME_SIZE);
+    b->pins[44].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
+    b->pins[44].gpio.pinmap = (1*32 + 31);
+    b->pins[44].gpio.parent_id = 0;
+    b->pins[44].gpio.mux_total = 0;
+
+    strncpy(b->pins[45].name, "X_AM335_NMIn", MRAA_PIN_NAME_SIZE);
+    b->pins[45].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[46].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[46].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    // NOT DONE / TESTED YET
+    strncpy(b->pins[47].name, "X_AIN4", MRAA_PIN_NAME_SIZE);
+    b->pins[47].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 1, 0 };
+
+    // NOT DONE / TESTED YET
+    strncpy(b->pins[48].name, "X_AIN5", MRAA_PIN_NAME_SIZE);
+    b->pins[48].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 1, 0 };
+
+    // NOT DONE / TESTED YET
+    strncpy(b->pins[49].name, "X_AIN6", MRAA_PIN_NAME_SIZE);
+    b->pins[49].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 1, 0 };
+
+    // NOT DONE / TESTED YET
+    strncpy(b->pins[50].name, "X_AIN7", MRAA_PIN_NAME_SIZE);
+    b->pins[50].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 1, 0 };
+
+    strncpy(b->pins[51].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[51].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    /* to CHECK X_GPIO_CKSYNC */
+    strncpy(b->pins[52].name, "X_GPIO_CKSYNC", MRAA_PIN_NAME_SIZE);
+    b->pins[52].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[53].name, "X_USB_ID_EXP", MRAA_PIN_NAME_SIZE);
+    b->pins[53].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[54].name, "USB_VBUS_EXP", MRAA_PIN_NAME_SIZE);
+    b->pins[54].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[55].name, "X_USB1_CE", MRAA_PIN_NAME_SIZE);
+    b->pins[55].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[56].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[56].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[57].name, "VCC_BL", MRAA_PIN_NAME_SIZE);
+    b->pins[57].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[58].name, "X_BP_POWER", MRAA_PIN_NAME_SIZE);
+    b->pins[58].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[59].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[59].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60].name, "VCC5V_IN", MRAA_PIN_NAME_SIZE);
+    b->pins[60].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    // X70 connector
+    strncpy(b->pins[60+1].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[60+1].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+2].name, "X_LCD_D21", MRAA_PIN_NAME_SIZE);
+    b->pins[60+2].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+3].name, "X_LCD_D18", MRAA_PIN_NAME_SIZE);
+    b->pins[60+3].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+4].name, "X_LCD_D16", MRAA_PIN_NAME_SIZE);
+    b->pins[60+4].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+5].name, "X_LCD_D0", MRAA_PIN_NAME_SIZE);
+    b->pins[60+5].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+6].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[60+6].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+7].name, "X_LCD_D1", MRAA_PIN_NAME_SIZE);
+    b->pins[60+7].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+8].name, "X_LCD_D2", MRAA_PIN_NAME_SIZE);
+    b->pins[60+8].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+9].name, "X_LCD_D3", MRAA_PIN_NAME_SIZE);
+    b->pins[60+9].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+10].name, "X_LCD_D4", MRAA_PIN_NAME_SIZE);
+    b->pins[60+10].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+11].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[60+11].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+12].name, "X_LCD_D22", MRAA_PIN_NAME_SIZE);
+    b->pins[60+12].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+13].name, "X_LCD_D19", MRAA_PIN_NAME_SIZE);
+    b->pins[60+13].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+14].name, "X_LCD_D5", MRAA_PIN_NAME_SIZE);
+    b->pins[60+14].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+15].name, "X_LCD_D6", MRAA_PIN_NAME_SIZE);
+    b->pins[60+15].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+16].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[60+16].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+17].name, "X_LCD_D7", MRAA_PIN_NAME_SIZE);
+    b->pins[60+17].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+18].name, "X_LCD_D8", MRAA_PIN_NAME_SIZE);
+    b->pins[60+18].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+19].name, "X_LCD_D9", MRAA_PIN_NAME_SIZE);
+    b->pins[60+19].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+20].name, "X_LCD_D10", MRAA_PIN_NAME_SIZE);
+    b->pins[60+20].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+21].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[60+21].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+22].name, "X_LCD_D23", MRAA_PIN_NAME_SIZE);
+    b->pins[60+22].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+23].name, "X_LCD_D20", MRAA_PIN_NAME_SIZE);
+    b->pins[60+23].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+24].name, "X_LCD_D17", MRAA_PIN_NAME_SIZE);
+    b->pins[60+24].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+25].name, "X_LCD_D11", MRAA_PIN_NAME_SIZE);
+    b->pins[60+25].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+26].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[60+26].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+27].name, "X_LCD_D12", MRAA_PIN_NAME_SIZE);
+    b->pins[60+27].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+28].name, "X_LCD_D13", MRAA_PIN_NAME_SIZE);
+    b->pins[60+28].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+29].name, "X_LCD_D14", MRAA_PIN_NAME_SIZE);
+    b->pins[60+29].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+30].name, "X_LCD_D15", MRAA_PIN_NAME_SIZE);
+    b->pins[60+30].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+31].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[60+31].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+32].name, "X_LCD_PCLK", MRAA_PIN_NAME_SIZE);
+    b->pins[60+32].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+33].name, "X_LCD_BIAS_EN", MRAA_PIN_NAME_SIZE);
+    b->pins[60+33].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+34].name, "X_LCD_HSYNC", MRAA_PIN_NAME_SIZE);
+    b->pins[60+34].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+35].name, "X_LCD_VSYNC", MRAA_PIN_NAME_SIZE);
+    b->pins[60+35].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+36].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[60+36].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+37].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[60+37].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+38].name, "X_PWM1_OUT", MRAA_PIN_NAME_SIZE);
+    b->pins[60+38].capabilities = (mraa_pincapabilities_t){ 1, 0, 1, 0, 0, 0, 0, 0 };
+    b->pins[60+38].pwm.pinmap = 0;
+    b->pins[60+38].pwm.mux_total = 0;
+
+    strncpy(b->pins[60+39].name, "VCC_BL", MRAA_PIN_NAME_SIZE);
+    b->pins[60+39].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+40].name, "VCC5V", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    // X71 connector
+    strncpy(b->pins[60+40+1].name, "X_I2S_CLK", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+1].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+40+2].name, "X_I2S_FRM", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+2].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+40+3].name, "X_I2S_ADC", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+3].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+40+4].name, "X_I2S_DAC", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+4].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    /* PIN-Number "60+40+5" with name "X_AV_INT_GPIO1_30" */
+    strncpy(b->pins[60+40+5].name, "X_GPIO1_30", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+5].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
+    b->pins[60+40+5].gpio.pinmap = (1*32 + 30);
+    b->pins[60+40+5].gpio.parent_id = 0;
+    b->pins[60+40+5].gpio.mux_total = 0;
+
+    /* PIN-Number "60+40+6" with name "nUSB1_OC_GPIO3_19 or" */
+    /* PIN-Number "60+40+6" with name "X_MCASP0_AHCLKX_GPIO3_21" */
+    // TODO -> Check settings of Jumper J77
+    strncpy(b->pins[60+40+6].name, "X_GPIO3_19", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+6].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
+    b->pins[60+40+6].gpio.pinmap = (3*32 + 19);
+    b->pins[60+40+6].gpio.parent_id = 0;
+    b->pins[60+40+6].gpio.mux_total = 0;
+
+    strncpy(b->pins[60+40+7].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+7].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+40+8].name, "nRESET_OUT", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+8].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+40+9].name, "TS_X+", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+9].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+40+10].name, "TS_X-", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+10].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+40+11].name, "TS_Y+", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+11].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+40+12].name, "TS_Y-", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+12].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+40+13].name, "VCC3V3", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+13].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+40+14].name, "GND", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+14].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+
+    strncpy(b->pins[60+40+15].name, "X_I2C0_SCL", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+15].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 };
+    b->pins[60+40+15].i2c.mux_total = 0;
+
+    strncpy(b->pins[60+40+16].name, "X_I2C0_SDA", MRAA_PIN_NAME_SIZE);
+    b->pins[60+40+16].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 };
+    b->pins[60+40+16].i2c.mux_total = 0;
+
+    // BUS DEFINITIONS
+    b->i2c_bus_count = 2;
+    b->def_i2c_bus = 0;
+    b->i2c_bus[0].bus_id = 0;
+    b->i2c_bus[0].sda = 11;
+    b->i2c_bus[0].scl = 13;
+    b->i2c_bus[1].bus_id = 0;
+    b->i2c_bus[1].sda = (60+40+16);
+    b->i2c_bus[1].scl = (60+40+15);
+
+    b->spi_bus_count = 1;
+    b->def_spi_bus = 0;
+    b->spi_bus[0].bus_id = 0;
+    b->spi_bus[0].slave_s = 0;
+    b->spi_bus[0].cs = 5;
+    b->spi_bus[0].mosi = 6;
+    b->spi_bus[0].miso = 7;
+    b->spi_bus[0].sclk = 8;
+
+    b->uart_dev_count = 4;
+    b->def_uart_dev = 0;
+    b->uart_dev[0].rx = 10;
+    b->uart_dev[0].tx = 12;
+    /*  TODO UART1  */
+    b->uart_dev[1].rx = 0;
+    b->uart_dev[1].tx = 0;
+    /*  TODO UART1  */
+    b->uart_dev[2].rx = 31;
+    b->uart_dev[2].tx = 33;
+    b->uart_dev[3].rx = 35;
+    b->uart_dev[3].tx = 36;
+
+    b->gpio_count = 0;
+    int i;
+    for (i = 0; i < b->phy_pin_count; i++)
+        if (b->pins[i].capabilities.gpio)
+            b->gpio_count++;
+    return b;
+error:
+    syslog(LOG_CRIT, "phyboard: failed to initialize");
+    free(b);
+
+    return NULL;
+};

--- a/src/arm/phyboard.c
+++ b/src/arm/phyboard.c
@@ -400,7 +400,7 @@ mraa_phyboard()
     b->pins[44].gpio.mux_total = 0;
 
     /* changed name "X_AM335_NMIn" to "X_AM335_NMI" for fitting in b->pins[45].name*/
-    strncpy(b->pins[45].name, "X_AM335_NMIn", MRAA_PIN_NAME_SIZE);
+    strncpy(b->pins[45].name, "X_AM335_NMI", MRAA_PIN_NAME_SIZE);
     b->pins[45].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
 
     strncpy(b->pins[46].name, "GND", MRAA_PIN_NAME_SIZE);

--- a/src/python/python2/docs/index.rst
+++ b/src/python/python2/docs/index.rst
@@ -27,6 +27,7 @@ Supported Platforms
    * `Raspberry Pi <../rasppi.html>`_
    * `Banana Pi/Pro <../bananapi.html>`_
    * `Beaglebone Black <../beaglebone.html>`_
+   * `phyBOARD-Wega <../phyboard-wega.html>`_
    * `Intel NUC NUC5i5MYBE <../nuc5.html>`_
    * `UP <../up.html>`_
    * `FTDI FT4222H <../ft4222.html>`_


### PR DESCRIPTION
Like the beaglebone, the phyBOARD-Wega also got an am335x.
So I merged the four mmap-functions for gpio_context and some
identical defines in a separate header and c-file.
The new platform support-files are based on beaglebone-files.

The documentation of phyBOARD-Wega is still in process,
but for now there are enough informations.
At this time it is possible to use GPIO-Pins and Uart0
(tested via python with mraa). The code for using SPI, I2C and
PWM is also still in process and not tested yet.

Signed-off-by: Norbert Wesp <nwesp@phytec.de>