### PR TITLE
added close of file handle

### DIFF
--- a/src/i2c/i2c.c
+++ b/src/i2c/i2c.c
@@ -441,6 +441,7 @@ mraa_i2c_stop(mraa_i2c_context dev)
         return dev->advance_func->i2c_stop_replace(dev);
     }
 
+    close(dev->fh);
     free(dev);
     return MRAA_SUCCESS;
 }


### PR DESCRIPTION
Will testing multiple i2c devices running in multiple threads we noticed that closing and opening a device would leave behind an open file descriptor we added one line of code to ensure the file descriptor is closed properly when we close a i2c device.