### PR TITLE
Add support for UART hardware flow control CTS RTS

### DIFF
--- a/include/mraa_internal_types.h
+++ b/include/mraa_internal_types.h
@@ -340,6 +340,8 @@ typedef struct {
     unsigned int index; /**< ID as exposed in the system */
     int rx; /**< uart rx */
     int tx; /**< uart tx */
+    int cts; /**< uart cts */
+    int rts; /**< uart rts */
     char* device_path; /**< To store "/dev/ttyS1" for example */
     /*@}*/
 } mraa_uart_dev_t;


### PR DESCRIPTION
add support for hardware flow control pin in uart pin  definition
Then each platform can configure those pin or the uart library can enable or disable them based on uart mode selected