### PR TITLE
Enabling mraa on raspberrypi3

### DIFF
--- a/src/arm/arm.c
+++ b/src/arm/arm.c
@@ -50,6 +50,8 @@ mraa_arm_platform()
                     platform_type = MRAA_RASPBERRY_PI;
                 } else if (strstr(line, "BCM2709")) {
                     platform_type = MRAA_RASPBERRY_PI;
+                } else if (strstr(line, "BCM2835")) {
+                    platform_type = MRAA_RASPBERRY_PI;
                 } else if (strstr(line, "Generic AM33XX")) {
                     if(mraa_file_contains("/proc/device-tree/model", "phyBOARD-WEGA")) {
                         platform_type = MRAA_PHYBOARD_WEGA;

--- a/src/arm/raspberry_pi.c
+++ b/src/arm/raspberry_pi.c
@@ -585,6 +585,7 @@ mraa_raspberry_pi()
     if ((platform_detected == PLATFORM_RASPBERRY_PI_A_PLUS_REV_1) ||
         (platform_detected == PLATFORM_RASPBERRY_PI_B_PLUS_REV_1) ||
         (platform_detected == PLATFORM_RASPBERRY_PI2_B_REV_1) ||
+        (platform_detected == PLATFORM_RASPBERRY_PI3_B) ||
         (platform_detected == PLATFORM_RASPBERRY_PI_ZERO)) {
 
         strncpy(b->pins[27].name, "ID_SD", MRAA_PIN_NAME_SIZE);


### PR DESCRIPTION
Proposal to detect raspberrypi 3 in arm.c and raspberry_pi.c which enables to use mraa and upm on a raspberrypi3.

Tested with debian stretch image kernel 4.9 with some leds and meteo sensors