### PR TITLE
mraa: Fix issues with gpio mapping

### DIFF
--- a/docs/joule.md
+++ b/docs/joule.md
@@ -46,6 +46,9 @@ Pin Mapping
 The Intel Joule expansion board has two breakouts, breakout #1 is 1-40 whilst breakout2 is 41-80. The
 LEDs are numbered from 100-103.
 
+ISH UART are named as: IURT
+ISH I2C are named as:IIC
+
 | MRAA Number | Physical Pin | Function |
 |-------------|--------------|----------|
 | 1           | GPIO         | GPIO     |
@@ -118,16 +121,16 @@ LEDs are numbered from 100-103.
 | 68          | UART0RX      | GPIO UART|
 | 69          | SPP0RX       | GPIO SPI |
 | 70          | UART0RT      | GPIO UART|
-| 71          | I2C1SDA      | GPIO I2C |
+| 71          | IIC0SDA      | GPIO I2C |
 | 72          | UART0CT      | GPIO UART|
-| 73          | I2C1SCL      | GPIO I2C |
-| 74          | UART1TX      | GPIO UART|
-| 75          | I2C2SDA      | GPIO I2C |
-| 76          | UART1RX      | GPIO UART|
-| 77          | I2C2SCL      | GPIO I2C |
-| 78          | UART1RT      | GPIO UART|
+| 73          | IIC0SCL      | GPIO I2C |
+| 74          | IURT1TX      | GPIO UART|
+| 75          | IIC1SDA      | GPIO I2C |
+| 76          | IURT1RX      | GPIO UART|
+| 77          | IIC1SCL      | GPIO I2C |
+| 78          | IURT1RT      | GPIO UART|
 | 79          | RTC_CLK      | GPIO     |
-| 80          | UART1CT      | GPIO UART|
+| 80          | IURT1CT      | GPIO UART|
 | 100         | LED100       | GPIO     |
 | 101         | LED101       | GPIO 	|
 | 102         | LED102       | GPIO 	|

--- a/src/x86/intel_joule_expansion.c
+++ b/src/x86/intel_joule_expansion.c
@@ -151,6 +151,7 @@ mraa_joule_expansion_board()
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 0, 0, 0, 0, 0, 0, 0, 0 };
     pos++;
 
+    // pin 1
     strncpy(b->pins[pos].name, "GPIO22", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
     b->pins[pos].gpio.pinmap = 451;
@@ -189,10 +190,9 @@ mraa_joule_expansion_board()
     pos++;
 
     strncpy(b->pins[pos].name, "UART0TX", 8);
-    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
-    // not configured as GPIO
-    //b->pins[pos].gpio.pinmap = 462;
-    //b->pins[pos].gpio.mux_total = 0;
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    b->pins[pos].gpio.pinmap = 468;
+    b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].uart.pinmap = 0;
     b->pins[pos].uart.parent_id = 0;
     b->pins[pos].uart.mux_total = 0;
@@ -211,13 +211,13 @@ mraa_joule_expansion_board()
     //b->pins[pos].gpio.mux_total = 0;
     pos++;
 
+    // pin 10
     strncpy(b->pins[pos].name, "SPP1CLK", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 1, 0, 0, 0 };
     b->pins[pos].gpio.pinmap = 416;
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
-    // pin 11
     strncpy(b->pins[pos].name, "I2C0SDA", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 };
     b->pins[pos].gpio.pinmap = 315;
@@ -248,7 +248,7 @@ mraa_joule_expansion_board()
 
     strncpy(b->pins[pos].name, "I2C1SDA", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 331;
+    b->pins[pos].gpio.pinmap = 317;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
@@ -262,7 +262,7 @@ mraa_joule_expansion_board()
 
     strncpy(b->pins[pos].name, "I2C1SCL", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 332;
+    b->pins[pos].gpio.pinmap = 318;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
     b->pins[pos].i2c.mux_total = 0;
@@ -276,31 +276,31 @@ mraa_joule_expansion_board()
 
     strncpy(b->pins[pos].name, "I2C2SDA", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 333;
+    b->pins[pos].gpio.pinmap = 319;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
     b->pins[pos].i2c.mux_total = 0;
     pos++;
 
+    // pin 20
     strncpy(b->pins[pos].name, "I2S1MCL", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
     b->pins[pos].gpio.pinmap = 378;
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
-    // pin 21
     strncpy(b->pins[pos].name, "I2C2SCL", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 334;
+    b->pins[pos].gpio.pinmap = 320;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
     pos++;
 
     strncpy(b->pins[pos].name, "UART1TX", 8);
-    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
-    //b->pins[pos].gpio.pinmap = 472;
-    //b->pins[pos].gpio.mux_total = 0;
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    b->pins[pos].gpio.pinmap = 472;
+    b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].uart.pinmap = 0;
     b->pins[pos].uart.parent_id = 0;
     b->pins[pos].uart.mux_total = 0;
@@ -313,9 +313,9 @@ mraa_joule_expansion_board()
     pos++;
 
     strncpy(b->pins[pos].name, "UART1RX", 8);
-    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
-    //b->pins[pos].gpio.pinmap = 471;
-    //b->pins[pos].gpio.mux_total = 0;
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    b->pins[pos].gpio.pinmap = 471;
+    b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].uart.pinmap = 0;
     b->pins[pos].uart.parent_id = 0;
     b->pins[pos].uart.mux_total = 0;
@@ -358,6 +358,7 @@ mraa_joule_expansion_board()
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
+    // pin 30
     strncpy(b->pins[pos].name, "PWM2", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 1, 0, 0, 0, 0, 0 };
     b->pins[pos].gpio.pinmap = 465;
@@ -367,12 +368,10 @@ mraa_joule_expansion_board()
     b->pins[pos].pwm.mux_total = 0;
     pos++;
 
-    // pin 31
-    strncpy(b->pins[pos].name, "ISH_IO2", 8);
-    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
-    // High level will be V1P8 - VBE on MBT3904D
-    b->pins[pos].gpio.pinmap = 339;
-    b->pins[pos].gpio.mux_total = 0;
+    strncpy(b->pins[pos].name, "I2S3SDO", 8);
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
+    //b->pins[pos].gpio.pinmap = 400;
+    //b->pins[pos].gpio.mux_total = 0;
     pos++;
 
     strncpy(b->pins[pos].name, "PWM3", 8);
@@ -418,6 +417,7 @@ mraa_joule_expansion_board()
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
     pos++;
 
+    // pin 40
     strncpy(b->pins[pos].name, "3.3V", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
     pos++;
@@ -459,6 +459,7 @@ mraa_joule_expansion_board()
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
     pos++;
 
+    // pin 50
     strncpy(b->pins[pos].name, "1.8V", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
     pos++;
@@ -509,6 +510,7 @@ mraa_joule_expansion_board()
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
+    // pin 60
     strncpy(b->pins[pos].name, "CAMERA", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };
     pos++;
@@ -527,7 +529,7 @@ mraa_joule_expansion_board()
 
     strncpy(b->pins[pos].name, "SPP0FS2", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 1, 0, 0, 0 };
-    b->pins[pos].gpio.pinmap = 411;
+    b->pins[pos].gpio.pinmap = 413;
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
@@ -538,8 +540,9 @@ mraa_joule_expansion_board()
     pos++;
 
     strncpy(b->pins[pos].name, "SPP0FS3", 8);
-    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 1, 0, 0, 0 };
-    b->pins[pos].gpio.pinmap = 410;
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 0 };
+    // There is nothing called SPP0FS3
+    //b->pins[pos].gpio.pinmap = 410;
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
@@ -570,8 +573,9 @@ mraa_joule_expansion_board()
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
+    // pin 70
     strncpy(b->pins[pos].name, "UART0RT", 8);
-    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
     b->pins[pos].gpio.pinmap = 469;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].uart.pinmap = 0;
@@ -579,67 +583,69 @@ mraa_joule_expansion_board()
     b->pins[pos].uart.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "I2C1SDA", 8);
+    strncpy(b->pins[pos].name, "IIC0SDA", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 317;
+    b->pins[pos].gpio.pinmap = 331;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
     b->pins[pos].i2c.mux_total = 0;
     pos++;
 
     strncpy(b->pins[pos].name, "UART0CT", 8);
-    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
-    b->pins[pos].gpio.pinmap = 412;
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    b->pins[pos].gpio.pinmap = 470;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].uart.pinmap = 0;
     b->pins[pos].uart.parent_id = 0;
     b->pins[pos].uart.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "I2C1SCL", 8);
+    strncpy(b->pins[pos].name, "IIC0SCL", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 318;
+    b->pins[pos].gpio.pinmap = 332;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
     b->pins[pos].i2c.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "UART1TX", 8);
-    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
-    b->pins[pos].gpio.pinmap = 484;
-    b->pins[pos].gpio.mux_total = 0;
+    strncpy(b->pins[pos].name, "IURT1TX", 8);
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    // Not available in breakout
+    //b->pins[pos].gpio.pinmap = 484;
+    //b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].uart.pinmap = 0;
     b->pins[pos].uart.parent_id = 0;
     b->pins[pos].uart.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "I2C2SDA", 8);
+    strncpy(b->pins[pos].name, "IIC1SDA", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 319;
+    b->pins[pos].gpio.pinmap = 333;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
     b->pins[pos].i2c.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "UART1RX", 8);
-    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
-    b->pins[pos].gpio.pinmap = 483;
-    b->pins[pos].gpio.mux_total = 0;
+    strncpy(b->pins[pos].name, "IURT1RX", 8);
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
+    // Not available in breakout
+    //b->pins[pos].gpio.pinmap = 483;
+    //b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].uart.pinmap = 0;
     b->pins[pos].uart.parent_id = 0;
     b->pins[pos].uart.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "I2C1SCL", 8);
+    strncpy(b->pins[pos].name, "IIC1SCL", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 320;
+    b->pins[pos].gpio.pinmap = 334;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
     b->pins[pos].i2c.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "UART1RT", 8);
-    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
+    strncpy(b->pins[pos].name, "IURT1RT", 8);
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
     b->pins[pos].gpio.pinmap = 485;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].uart.pinmap = 0;
@@ -653,8 +659,9 @@ mraa_joule_expansion_board()
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "UART1CT", 8);
-    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
+    // pin 80
+    strncpy(b->pins[pos].name, "IURT1CT", 8);
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
     b->pins[pos].gpio.pinmap = 486;
     b->pins[pos].uart.pinmap = 0;
     b->pins[pos].uart.parent_id = 0;
@@ -690,13 +697,13 @@ mraa_joule_expansion_board()
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "LEDWIFI", 8);
+    strncpy(b->pins[pos].name, "LEDBT", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
     b->pins[pos].gpio.pinmap = 438;
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "LEDBT", 8);
+    strncpy(b->pins[pos].name, "LEDWIFI", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
     b->pins[pos].gpio.pinmap = 439;
     b->pins[pos].gpio.mux_total = 0;


### PR DESCRIPTION
The GPIOs are not mapped correctly in MRAA for tuchuk board.

This patch corrects the GPIO maps and the PIN assignments.

Note:
1) There are nothing called I2S(x)SDO and I2S(x)SDI available over breakout
   pins, the usage is commented now.
2) There is nothing called SPP0FS3, is now commented, what we have is SPP1FS3.
3) I2C1SDA available twise 15 and 71. PIN 71 as per gpio used should be renamed as ISHI2C0SDA
4) I2C1SCL available twise 17 and 73. PIN 73 as per gpio used should be renamed as ISHI2C0SCL
5) UART1TX available twise 22 and 74. PIN 74 as per gpio used is ISHUART1TXD
   and is not available in breakout.
6) UART1RX available twise 24 and 76. PIN 76 as per gpio used is ISHUART1RXD
   and is not available in breakout.
7) I2C2SDA available twise 19 and 75. PIN 75 as per gpio used is ISHI2C1SDA
   and is not available in breakout pins
8) I2C2SCL available twise 21 and 77. PIN 75 as per gpio used is ISHI2C1SCL
   and is not available in breakout pins
9) PIN 78 UART1RT as per GPIO used is ISHUART1RT and is not available in breakout pins
10) PIN 80 UART1CT as per GPIO is ISHUART1CT and is not available in breakout pins

BIOS used is 193

Signed-off-by: Arun Ravindran <arun.ravindran@intel.com>