### PR TITLE
joule: Fix issue with ISH UART name

### DIFF
--- a/docs/joule.md
+++ b/docs/joule.md
@@ -124,13 +124,13 @@ ISH I2C are named as:IIC
 | 71          | IIC0SDA      | GPIO I2C |
 | 72          | UART0CT      | GPIO UART|
 | 73          | IIC0SCL      | GPIO I2C |
-| 74          | IURT1TX      | GPIO UART|
+| 74          | IURT0TX      | GPIO UART|
 | 75          | IIC1SDA      | GPIO I2C |
-| 76          | IURT1RX      | GPIO UART|
+| 76          | IURT0RX      | GPIO UART|
 | 77          | IIC1SCL      | GPIO I2C |
-| 78          | IURT1RT      | GPIO UART|
+| 78          | IURT0RT      | GPIO UART|
 | 79          | RTC_CLK      | GPIO     |
-| 80          | IURT1CT      | GPIO UART|
+| 80          | IURT0CT      | GPIO UART|
 | 100         | LED100       | GPIO     |
 | 101         | LED101       | GPIO 	|
 | 102         | LED102       | GPIO 	|

--- a/src/x86/intel_joule_expansion.c
+++ b/src/x86/intel_joule_expansion.c
@@ -609,11 +609,10 @@ mraa_joule_expansion_board()
     b->pins[pos].i2c.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "IURT1TX", 8);
+    strncpy(b->pins[pos].name, "IURT0TX", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
-    // Not available in breakout
-    //b->pins[pos].gpio.pinmap = 484;
-    //b->pins[pos].gpio.mux_total = 0;
+    b->pins[pos].gpio.pinmap = 484;
+    b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].uart.pinmap = 0;
     b->pins[pos].uart.parent_id = 0;
     b->pins[pos].uart.mux_total = 0;
@@ -627,11 +626,10 @@ mraa_joule_expansion_board()
     b->pins[pos].i2c.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "IURT1RX", 8);
+    strncpy(b->pins[pos].name, "IURT0RX", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
-    // Not available in breakout
-    //b->pins[pos].gpio.pinmap = 483;
-    //b->pins[pos].gpio.mux_total = 0;
+    b->pins[pos].gpio.pinmap = 483;
+    b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].uart.pinmap = 0;
     b->pins[pos].uart.parent_id = 0;
     b->pins[pos].uart.mux_total = 0;
@@ -645,7 +643,7 @@ mraa_joule_expansion_board()
     b->pins[pos].i2c.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "IURT1RT", 8);
+    strncpy(b->pins[pos].name, "IURT0RT", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
     b->pins[pos].gpio.pinmap = 485;
     b->pins[pos].gpio.mux_total = 0;
@@ -661,7 +659,7 @@ mraa_joule_expansion_board()
     pos++;
 
     // pin 80
-    strncpy(b->pins[pos].name, "IURT1CT", 8);
+    strncpy(b->pins[pos].name, "IURT0CT", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
     b->pins[pos].gpio.pinmap = 486;
     b->pins[pos].uart.pinmap = 0;


### PR DESCRIPTION
MRAA is using gpio 484, 483, 485 and 486 as ISH UART1.
But J13 expansion connector doesn't expose ISH UART1,
instead it exposes ISH UART0 as per dev kit hardware guide.

This patch fixes this descrpency and renames the UART and
also enables the GPIO usage.

Signed-off-by: Arun Ravindran <arun.ravindran@intel.com>