### PR TITLE
joule: Fixing descripencies in gpio numbers

### DIFF
--- a/docs/joule.md
+++ b/docs/joule.md
@@ -65,13 +65,13 @@ ISH I2C are named as:IIC
 | 12          | I2S1SDI      | GPIO     |
 | 13          | I2C0SCL      | I2C      |
 | 14          | I2S1SDO      | GPIO     |
-| 15          | I2C1SDA      | I2C      |
+| 15          | IIC0SDA      | I2C      |
 | 16          | I2S1WS       | GPIO     |
-| 17          | I2C1SCL      | I2C      |
+| 17          | IIC0SCL      | I2C      |
 | 18          | I2S1CLK      | GPIO     |
-| 19          | I2C2SDA      | I2C      |
+| 19          | IIC1SDA      | I2C      |
 | 20          | I2S1MCL      | GPIO     |
-| 21          | I2C2SCL	     | I2CO     |
+| 21          | IIC1SCL	     | I2CO     |
 | 22          | UART1TX	     | UART     |
 | 23          | I2S4SDO      | NONE     |
 | 24          | UART1RX      | UART     |
@@ -115,19 +115,19 @@ ISH I2C are named as:IIC
 | 62          | SPI_DAT      | SPI      |
 | 63          | SPP0FS2      | GPIO SPI |
 | 64          | SPICLKB      | GPIO     |
-| 65          | SPP0FS3      | GPIO SPI |
+| 65          | SPI0CLK      | GPIO SPI |
 | 66          | SPICLKA      | GPIO     |
 | 67          | SPP0TX       | GPIO SPI |
 | 68          | UART0RX      | GPIO UART|
 | 69          | SPP0RX       | GPIO SPI |
 | 70          | UART0RT      | GPIO UART|
-| 71          | IIC0SDA      | GPIO I2C |
+| 71          | I2C1SDA      | GPIO I2C |
 | 72          | UART0CT      | GPIO UART|
-| 73          | IIC0SCL      | GPIO I2C |
+| 73          | I2C1SCL      | GPIO I2C |
 | 74          | IURT0TX      | GPIO UART|
-| 75          | IIC1SDA      | GPIO I2C |
+| 75          | I2C2SDA      | GPIO I2C |
 | 76          | IURT0RX      | GPIO UART|
-| 77          | IIC1SCL      | GPIO I2C |
+| 77          | I2C2SCL      | GPIO I2C |
 | 78          | IURT0RT      | GPIO UART|
 | 79          | RTC_CLK      | GPIO     |
 | 80          | IURT0CT      | GPIO UART|

--- a/src/x86/intel_joule_expansion.c
+++ b/src/x86/intel_joule_expansion.c
@@ -246,9 +246,9 @@ mraa_joule_expansion_board()
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "I2C1SDA", 8);
+    strncpy(b->pins[pos].name, "II0SDA", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 317;
+    b->pins[pos].gpio.pinmap = 331;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
@@ -260,9 +260,9 @@ mraa_joule_expansion_board()
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "I2C1SCL", 8);
+    strncpy(b->pins[pos].name, "IIC0SCL", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 318;
+    b->pins[pos].gpio.pinmap = 332;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
     b->pins[pos].i2c.mux_total = 0;
@@ -274,9 +274,9 @@ mraa_joule_expansion_board()
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "I2C2SDA", 8);
+    strncpy(b->pins[pos].name, "IIC1SDA", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 319;
+    b->pins[pos].gpio.pinmap = 333;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
     b->pins[pos].i2c.mux_total = 0;
@@ -289,9 +289,9 @@ mraa_joule_expansion_board()
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "I2C2SCL", 8);
+    strncpy(b->pins[pos].name, "IIC1SCL", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 320;
+    b->pins[pos].gpio.pinmap = 334;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
@@ -540,10 +540,9 @@ mraa_joule_expansion_board()
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "SPP0FS3", 8);
-    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 0 };
-    // There is nothing called SPP0FS3
-    //b->pins[pos].gpio.pinmap = 410;
+    strncpy(b->pins[pos].name, "SPP0CLK", 8);
+    b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 1, 0, 0, 0 };
+    b->pins[pos].gpio.pinmap = 410;
     b->pins[pos].gpio.mux_total = 0;
     pos++;
 
@@ -584,9 +583,9 @@ mraa_joule_expansion_board()
     b->pins[pos].uart.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "IIC0SDA", 8);
+    strncpy(b->pins[pos].name, "I2C1SDA", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 331;
+    b->pins[pos].gpio.pinmap = 317;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
     b->pins[pos].i2c.mux_total = 0;
@@ -601,9 +600,9 @@ mraa_joule_expansion_board()
     b->pins[pos].uart.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "IIC0SCL", 8);
+    strncpy(b->pins[pos].name, "I2C1SCL", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 332;
+    b->pins[pos].gpio.pinmap = 318;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
     b->pins[pos].i2c.mux_total = 0;
@@ -611,16 +610,16 @@ mraa_joule_expansion_board()
 
     strncpy(b->pins[pos].name, "IURT0TX", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
-    b->pins[pos].gpio.pinmap = 484;
+    b->pins[pos].gpio.pinmap = 480;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].uart.pinmap = 0;
     b->pins[pos].uart.parent_id = 0;
     b->pins[pos].uart.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "IIC1SDA", 8);
+    strncpy(b->pins[pos].name, "I2C2SDA", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 333;
+    b->pins[pos].gpio.pinmap = 319;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
     b->pins[pos].i2c.mux_total = 0;
@@ -628,16 +627,16 @@ mraa_joule_expansion_board()
 
     strncpy(b->pins[pos].name, "IURT0RX", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
-    b->pins[pos].gpio.pinmap = 483;
+    b->pins[pos].gpio.pinmap = 479;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].uart.pinmap = 0;
     b->pins[pos].uart.parent_id = 0;
     b->pins[pos].uart.mux_total = 0;
     pos++;
 
-    strncpy(b->pins[pos].name, "IIC1SCL", 8);
+    strncpy(b->pins[pos].name, "I2C2SCL", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 1, 0, 0 };
-    b->pins[pos].gpio.pinmap = 334;
+    b->pins[pos].gpio.pinmap = 320;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].i2c.pinmap = 0;
     b->pins[pos].i2c.mux_total = 0;
@@ -645,7 +644,7 @@ mraa_joule_expansion_board()
 
     strncpy(b->pins[pos].name, "IURT0RT", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
-    b->pins[pos].gpio.pinmap = 485;
+    b->pins[pos].gpio.pinmap = 481;
     b->pins[pos].gpio.mux_total = 0;
     b->pins[pos].uart.pinmap = 0;
     b->pins[pos].uart.parent_id = 0;
@@ -661,7 +660,7 @@ mraa_joule_expansion_board()
     // pin 80
     strncpy(b->pins[pos].name, "IURT0CT", 8);
     b->pins[pos].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 1 };
-    b->pins[pos].gpio.pinmap = 486;
+    b->pins[pos].gpio.pinmap = 482;
     b->pins[pos].uart.pinmap = 0;
     b->pins[pos].uart.parent_id = 0;
     b->pins[pos].uart.mux_total = 0;


### PR DESCRIPTION
The earlier patches did not fix the following issues.

1) gpio number used for ISH I2C 0 and I2C 1 were wrong
2) gpio number used in ISH I2C 1 and I2C 2 were wrong

This patch fixes this issue and also update the doc.

Signed-off-by: Arun Ravindran <arun.ravindran@intel.com>