### PR TITLE
Doxyfile.in: Use relative paths in generated docs

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -154,7 +154,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = 
+STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which


### PR DESCRIPTION
Updated Doxyfile to strip the full path to the base MRAA directory
from generated documentation.  This removes the build path from
MRAA documentation.

Old html:

aio_8h.html:<title>mraa: /iotdk/jenkins/workspace/upm-doc-stable/api/mraa/aio.h File Reference</title>

New html:

aio_8h.html:<title>mraa: api/mraa/aio.h File Reference</title>

Signed-off-by: Noel Eck <noel.eck@intel.com>