### PR TITLE
periphmraa: Create IndexLookup functions for GPIO, I2C, SPI, PWM.

### DIFF
--- a/api/mraa/common.h
+++ b/api/mraa/common.h
@@ -233,6 +233,44 @@ unsigned int mraa_get_platform_pin_count(uint8_t platform_offset);
 */
 char* mraa_get_pin_name(int pin);
 
+#if defined(PERIPHERALMAN)
+/**
+* Get pin number, board must be initialised.
+*
+* @param pin_name: GPIO Pin Name. Eg: IO0
+* @return int of MRAA index for gpio
+*/
+
+int mraa_gpio_lookup(char* pin_name);
+
+/**
+* Get pin number, board must be initialised.
+*
+* @param i2c_name: I2c Bus Name. Eg: I2C6
+* @return int of MRAA index of i2c bus
+*/
+
+int mraa_i2c_lookup(char* i2c_name);
+
+/**
+* Get pin number, board must be initialised.
+*
+* @param spi_name: Name of spi bus. Eg: SPI2
+* @return int for MRAA index of spi bus
+*/
+
+int mraa_spi_lookup(char* spi_name);
+
+/**
+* Get pin number, board must be initialised.
+*
+* @param pwm_name: Name of pwm. Eg:PWM0
+* @return int of MRAA index for pwm bus
+*/
+
+int mraa_pwm_lookup(char* pwm_name);
+#endif
+
 /**
  * Get default i2c bus, board must be initialised.
  *

--- a/api/mraa/common.hpp
+++ b/api/mraa/common.hpp
@@ -214,6 +214,60 @@ getPinName(int pin)
     return ret_val;
 }
 
+#if defined(PERIPHERALMAN)
+/**
+* Get pin number, board must be initialised.
+*
+* @param pin_name: GPIO Pin Name. Eg: IO0
+*
+* @return int of MRAA index for gpio
+*/
+inline int
+getGpioLookup(char* pin_name)
+{
+    return mraa_gpio_lookup(pin_name);
+}
+
+/**
+* Get pin number, board must be initialised.
+*
+* @param i2c_name: I2c Bus Name. Eg: I2C6
+*
+* @return int of MRAA index of i2c bus
+*/
+inline int
+getI2cLookup(char* i2c_name)
+{
+    return mraa_i2c_lookup(i2c_name);
+}
+
+/**
+* Get pin number, board must be initialised.
+*
+* @param spi_name: Name of spi bus. Eg: SPI2
+*
+* @return int for MRAA index of spi bus
+*/
+inline int
+getSpiLookup(char* spi_name)
+{
+    return mraa_spi_lookup(spi_name);
+}
+
+/**
+* Get pin number, board must be initialised.
+*
+* @param pwm_name: Name of pwm. Eg:PWM0
+*
+* @return int of MRAA index for pwm bus
+*/
+inline int
+getPwmLookup(char* pwm_name)
+{
+    return mraa_pwm_lookup(pwm_name);
+}
+#endif
+
 /**
  * Sets the log level to use from 0-7 where 7 is very verbose. These are the
  * syslog log levels, see syslog(3) for more information on the levels.

--- a/include/mraa_internal_types.h
+++ b/include/mraa_internal_types.h
@@ -339,6 +339,10 @@ typedef struct {
  */
 typedef struct {
     /*@{*/
+#if defined(PERIPHERALMAN)
+    char *name; /**< Peripheral manager's i2c name */
+#endif
+
     int bus_id; /**< ID as exposed in the system */
     int scl; /**< i2c SCL */
     int sda; /**< i2c SDA */
@@ -351,6 +355,9 @@ typedef struct {
  */
 typedef struct {
     /*@{*/
+#if defined(PERIPHERALMAN)
+    char *name; /**< Peripheral manager's spi name */
+#endif
     unsigned int bus_id; /**< The Bus ID as exposed to the system. */
     unsigned int slave_s; /**< Slave select */
     mraa_boolean_t three_wire; /**< Is the bus only a three wire system */
@@ -366,6 +373,9 @@ typedef struct {
  */
 typedef struct {
     /*@{*/
+#if defined(PERIPHERALMAN)
+    char *name; /**< Peripheral manager's uart name */
+#endif
     unsigned int index; /**< ID as exposed in the system */
     int rx; /**< uart rx */
     int tx; /**< uart tx */
@@ -378,6 +388,9 @@ typedef struct {
  */
 typedef struct {
     /*@{*/
+#if defined(PERIPHERALMAN)
+    char *name; /**< Peripheral manager's pwm name */
+#endif
     unsigned int index; /**< ID as exposed in the system */
     char* device_path; /**< To store "/dev/pwm" for example */
     /*@}*/

--- a/src/java/mraajava.i
+++ b/src/java/mraajava.i
@@ -106,7 +106,8 @@ class Spi;
             System.exit(1);
         }
 
-        if((mraa.class.getPackage().getSpecificationVersion() != null)
+        if(((mraa.class.getPackage().getSpecificationVersion() != null)
+                && (!mraa.class.getPackage().getSpecificationVersion().equals("0.0")))
                 && (mraa.getVersion() != null)){
             String javaAPIVersion = mraa.class.getPackage().getSpecificationVersion();
             String nativeAPIVersion = mraa.getVersion().substring(1);

--- a/src/mraa.c
+++ b/src/mraa.c
@@ -817,6 +817,60 @@ mraa_get_pin_name(int pin)
     return (char*) current_plat->pins[pin].name;
 }
 
+#if defined(PERIPHERALMAN)
+int mraa_gpio_lookup(char* pin_name)
+{
+    if (plat == NULL)
+        return -1;
+
+    int i = 0;
+    for (; i < plat->gpio_count; i++) {
+         if (0 == strcmp(pin_name, plat->pins[i].name))
+             return plat->pins[i].gpio.pinmap;
+    }
+    return -1;
+}
+
+int mraa_i2c_lookup(char* i2c_name)
+{
+    if (plat == NULL)
+        return -1;
+
+    int i = 0;
+    for (; i < plat->i2c_bus_count; i++) {
+         if (0 == strcmp(i2c_name, plat->i2c_bus[i].name))
+             return plat->i2c_bus[i].bus_id;
+    }
+    return -1;
+}
+
+int mraa_spi_lookup(char* spi_name)
+{
+    if (plat == NULL)
+        return -1;
+
+    int i = 0;
+    for (; i < plat->spi_bus_count; i++) {
+         if (0 == strcmp(spi_name, plat->spi_bus[i].name))
+             return plat->spi_bus[i].bus_id;
+    }
+    return -1;
+}
+
+int mraa_pwm_lookup(char* pwm_name)
+{
+    if (plat == NULL)
+        return -1;
+
+    int i = 0;
+    for (; i < plat->pwm_dev_count; i++) {
+         if (0 == strcmp(pwm_name, plat->pwm_dev[i].name))
+             return plat->pwm_dev[i].index;
+    }
+    return -1;
+}
+#endif
+
 int
 mraa_get_default_i2c_bus(uint8_t platform_offset)
 {

--- a/src/peripheralman/peripheralman.c
+++ b/src/peripheralman/peripheralman.c
@@ -788,6 +788,7 @@ mraa_peripheralman_plat_init()
 
     //Updating I2C bus structure
     for (i = 0; i < i2c_busses_count; i++) {
+        b->i2c_bus[i].name = i2c_busses[i];
         b->i2c_bus[i].bus_id = i;
         b->i2c_bus[i].sda = -1;
         b->i2c_bus[i].scl = -1;
@@ -795,6 +796,7 @@ mraa_peripheralman_plat_init()
 
     //Updating SPI bus structure
     for (i =0; i < spi_busses_count; i++) {
+        b->spi_bus[i].name = spi_busses[i];
         b->spi_bus[i].bus_id = i;
         b->spi_bus[i].slave_s = -1;
         b->spi_bus[i].three_wire = -1;
@@ -806,6 +808,7 @@ mraa_peripheralman_plat_init()
 
     //Updating PWM structure
     for (i = 0; i < pwm_dev_count; i++) {
+        b->pwm_dev[i].name = pwm_devices[i];
         b->pwm_dev[i].index = i;
     }
 


### PR DESCRIPTION
These lookups provide the MRAA index with the Pi/Bus name as input.

Signed-off-by: Vineela Tummalapalli <vineela.tummalapalli@intel.com>