### PR TITLE
periphmraa: Create IndexLookup functions for GPIO, I2C, SPI, PWM.

### DIFF
--- a/api/mraa/common.h
+++ b/api/mraa/common.h
@@ -234,6 +234,42 @@ unsigned int mraa_get_platform_pin_count(uint8_t platform_offset);
 char* mraa_get_pin_name(int pin);
 
 /**
+* Get pin number, board must be initialised.
+*
+* @param pin_name: GPIO Pin Name. Eg: IO0
+* @return int of MRAA index for gpio
+*/
+
+int mraa_gpio_lookup(const char* pin_name);
+
+/**
+* Get pin number, board must be initialised.
+*
+* @param i2c_name: I2c Bus Name. Eg: I2C6
+* @return int of MRAA index of i2c bus
+*/
+
+int mraa_i2c_lookup(const char* i2c_name);
+
+/**
+* Get pin number, board must be initialised.
+*
+* @param spi_name: Name of spi bus. Eg: SPI2
+* @return int for MRAA index of spi bus
+*/
+
+int mraa_spi_lookup(const char* spi_name);
+
+/**
+* Get pin number, board must be initialised.
+*
+* @param pwm_name: Name of pwm. Eg:PWM0
+* @return int of MRAA index for pwm bus
+*/
+
+int mraa_pwm_lookup(const char* pwm_name);
+
+/**
  * Get default i2c bus, board must be initialised.
  *
  * @return int default i2c bus index

--- a/api/mraa/common.hpp
+++ b/api/mraa/common.hpp
@@ -27,6 +27,8 @@
 #include "common.h"
 #include "types.hpp"
 #include <string>
+#include <sstream>
+#include <stdexcept>
 
 /**
  * @namespace mraa namespace
@@ -212,6 +214,90 @@ getPinName(int pin)
 {
     std::string ret_val(mraa_get_pin_name(pin));
     return ret_val;
+}
+
+/**
+* Get pin number, board must be initialised.
+*
+* @param pin_name: GPIO Pin Name. Eg: IO0
+* @throws std::invalid_argument if name is not valid
+* @return int of MRAA index for gpio
+*/
+inline int
+getGpioLookup(std::string pin_name)
+{
+    int index = mraa_gpio_lookup(pin_name.c_str());
+
+    if (index < 0){
+        std::ostringstream oss;
+        oss << "Gpio name " << pin_name << " is not valid";
+        throw std::invalid_argument(oss.str());
+    }
+
+    return index;
+}
+
+/**
+* Get pin number, board must be initialised.
+*
+* @param i2c_name: I2c Bus Name. Eg: I2C6
+* @throws std::invalid_argument if name is not valid
+* @return int of MRAA index of i2c bus
+*/
+inline int
+getI2cLookup(std::string i2c_name)
+{
+    int index = mraa_i2c_lookup(i2c_name.c_str());
+
+    if (index < 0){
+        std::ostringstream oss;
+        oss << "i2c name " << i2c_name << " is not valid";
+        throw std::invalid_argument(oss.str());
+    }
+
+    return index;
+}
+
+/**
+* Get pin number, board must be initialised.
+*
+* @param spi_name: Name of spi bus. Eg: SPI2
+* @throws std::invalid_argument if name is not valid
+* @return int for MRAA index of spi bus
+*/
+inline int
+getSpiLookup(std::string spi_name)
+{
+    int index = mraa_spi_lookup(spi_name.c_str());
+
+    if (index < 0){
+        std::ostringstream oss;
+        oss << "Spi name " << spi_name << " is not valid";
+        throw std::invalid_argument(oss.str());
+    }
+
+    return index;
+}
+
+/**
+* Get pin number, board must be initialised.
+*
+* @param pwm_name: Name of pwm. Eg:PWM0
+* @throws std::invalid_argument if name is not valid
+* @return int of MRAA index for pwm bus
+*/
+inline int
+getPwmLookup(std::string pwm_name)
+{
+    int index = mraa_pwm_lookup(pwm_name.c_str());
+
+    if (index < 0){
+        std::ostringstream oss;
+        oss << "PWM name " << pwm_name << " is not valid";
+        throw std::invalid_argument(oss.str());
+    }
+
+    return index;
 }
 
 /**

--- a/include/mraa_internal_types.h
+++ b/include/mraa_internal_types.h
@@ -339,6 +339,8 @@ typedef struct {
  */
 typedef struct {
     /*@{*/
+    char *name; /**< Peripheral manager's i2c name */
+
     int bus_id; /**< ID as exposed in the system */
     int scl; /**< i2c SCL */
     int sda; /**< i2c SDA */
@@ -351,6 +353,7 @@ typedef struct {
  */
 typedef struct {
     /*@{*/
+    char *name; /**< Peripheral manager's spi name */
     unsigned int bus_id; /**< The Bus ID as exposed to the system. */
     unsigned int slave_s; /**< Slave select */
     mraa_boolean_t three_wire; /**< Is the bus only a three wire system */
@@ -366,6 +369,7 @@ typedef struct {
  */
 typedef struct {
     /*@{*/
+    char *name; /**< Peripheral manager's uart name */
     unsigned int index; /**< ID as exposed in the system */
     int rx; /**< uart rx */
     int tx; /**< uart tx */
@@ -378,6 +382,7 @@ typedef struct {
  */
 typedef struct {
     /*@{*/
+    char *name; /**< Peripheral manager's pwm name */
     unsigned int index; /**< ID as exposed in the system */
     char* device_path; /**< To store "/dev/pwm" for example */
     /*@}*/

--- a/src/mraa.c
+++ b/src/mraa.c
@@ -817,6 +817,70 @@ mraa_get_pin_name(int pin)
     return (char*) current_plat->pins[pin].name;
 }
 
+int mraa_gpio_lookup(const char* pin_name)
+{
+    if (plat == NULL)
+        return -1;
+
+     if (strlen(pin_name) == 0)
+        return -1;
+
+    int i = 0;
+    for (; i < plat->gpio_count; i++) {
+         if (0 == strcmp(pin_name, plat->pins[i].name))
+             return plat->pins[i].gpio.pinmap;
+    }
+    return -1;
+}
+
+int mraa_i2c_lookup(const char* i2c_name)
+{
+    if (plat == NULL)
+        return -1;
+
+    if (strlen(i2c_name) == 0)
+        return -1;
+
+    int i = 0;
+    for (; i < plat->i2c_bus_count; i++) {
+         if (0 == strcmp(i2c_name, plat->i2c_bus[i].name))
+             return plat->i2c_bus[i].bus_id;
+    }
+    return -1;
+}
+
+int mraa_spi_lookup(const char* spi_name)
+{
+    if (plat == NULL)
+        return -1;
+
+    if (strlen(spi_name) == 0)
+        return -1;
+
+    int i = 0;
+    for (; i < plat->spi_bus_count; i++) {
+         if (0 == strcmp(spi_name, plat->spi_bus[i].name))
+             return plat->spi_bus[i].bus_id;
+    }
+    return -1;
+}
+
+int mraa_pwm_lookup(const char* pwm_name)
+{
+    if (plat == NULL)
+        return -1;
+
+    if (strlen(pwm_name) == 0)
+        return -1;
+
+    int i = 0;
+    for (; i < plat->pwm_dev_count; i++) {
+         if (0 == strcmp(pwm_name, plat->pwm_dev[i].name))
+             return plat->pwm_dev[i].index;
+    }
+    return -1;
+}
+
 int
 mraa_get_default_i2c_bus(uint8_t platform_offset)
 {

--- a/src/peripheralman/peripheralman.c
+++ b/src/peripheralman/peripheralman.c
@@ -788,6 +788,7 @@ mraa_peripheralman_plat_init()
 
     //Updating I2C bus structure
     for (i = 0; i < i2c_busses_count; i++) {
+        b->i2c_bus[i].name = i2c_busses[i];
         b->i2c_bus[i].bus_id = i;
         b->i2c_bus[i].sda = -1;
         b->i2c_bus[i].scl = -1;
@@ -795,6 +796,7 @@ mraa_peripheralman_plat_init()
 
     //Updating SPI bus structure
     for (i =0; i < spi_busses_count; i++) {
+        b->spi_bus[i].name = spi_busses[i];
         b->spi_bus[i].bus_id = i;
         b->spi_bus[i].slave_s = -1;
         b->spi_bus[i].three_wire = -1;
@@ -806,6 +808,7 @@ mraa_peripheralman_plat_init()
 
     //Updating PWM structure
     for (i = 0; i < pwm_dev_count; i++) {
+        b->pwm_dev[i].name = pwm_devices[i];
         b->pwm_dev[i].index = i;
     }
 


### PR DESCRIPTION
These lookups provide the MRAA index with the Pin/Bus name as input.

Signed-off-by: Vineela Tummalapalli <vineela.tummalapalli@intel.com>