### PR TITLE
mraa/joule: Update the documentation on SPI

### DIFF
--- a/docs/joule.md
+++ b/docs/joule.md
@@ -17,11 +17,11 @@ Interface notes
 Two SPI buses are available, with one chipselect each. Pins listed are MRAA
 numbered pins. Other chip selects are available if enabled in BIOS/EEPROM but
 cannot be enabled as BIOS options. You will need the spidev kernel module
-loaded, Ostro-XT does this by default.
+loaded, Ostro-XT and ref-os-iot does this by default.
 
 Bus 0 (32765)
-MOSI = 2
-MISO = 4
+MOSI = 4
+MISO = 2
 CS = 6
 CLK = 10
 


### PR DESCRIPTION
The existing documentation shows the MISO and MOSI
pins wrongly. As per the hardware document available
at http://www.intel.com/content/dam/support/us/en/documents/
joule-products/intel-joule-dev-kit-hardware-guide.pdf
pin2 should be MISO and pin 4, MOSI.

Signed-off-by: Arun Ravindran <arun.ravindran@intel.com>