### PR TITLE
JS examples: refactor for clarity and consistent style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,12 @@ language: cpp
 sudo: required
 dist: trusty
 env:
-  - NODE010=true
-  - NODE012=true
   - NODE4=true
   - NODE5=true
-  - JSONPLAT=true NODE010=true
-  - JSONPLAT=true NODE012=true
   - JSONPLAT=true NODE4=true
   - JSONPLAT=true NODE5=true
-  - MOCK=true NODE010=true
-  - MOCK=true NODE012=true
   - MOCK=true NODE4=true
   - MOCK=true NODE5=true
-  # node010 npm builds don't work in clang and anyone using npm should want to
-  # use something newer
   - NPM=true NODE4=true
   - NPM=true NODE5=true
 compiler:
@@ -31,15 +23,12 @@ before_script:
   - if [ "$CC" == "gcc" ]; then export BUILDJAVA=ON; export CC=gcc-4.8; export CXX=g++-4.8; else export BUILDJAVA=OFF; fi
   - if [ "${JSONPLAT}" ]; then export JSONPLAT=ON; else export JSONPLAT=OFF; fi
   - if [ "${MOCK}" ]; then export BUILDARCH="MOCK"; else export BUILDARCH=""; fi
-  - if [ "${NODE010}" ]; then nvm install 0.10; fi
-  - if [ "${NODE012}" ]; then nvm install 0.12; fi
   - if [ "${NODE4}" ]; then nvm install 4.1; fi
   - if [ "${NODE5}" ]; then nvm install 5; fi
   - npm install node-gyp && export NODE_GYP="$TRAVIS_BUILD_DIR/node_modules/node-gyp/bin/node-gyp.js"
-  # Handle 0.10 NODE_ROOT_DIR differently than other versions
   - wget http://iotdk.intel.com/misc/tr/swig-3.0.10.tar.gz && tar xf swig-3.0.10.tar.gz && cd swig-3.0.10 && ./configure --prefix=/home/travis/ && make && make install && cd ..
 script:
-  - echo "CC=$CC BUILDJAVA=$BUILDJAVA BUILDARCH=$BUILDARCH JSONPLAT=$JSONPLAT NODE010=$NODE010 NODE012=$NODE012 NODE4=$NODE4 NODE5=$NODE5 NODE_ROOT_DIR=$NODE_ROOT_DIR"
+  - echo "CC=$CC BUILDJAVA=$BUILDJAVA BUILDARCH=$BUILDARCH JSONPLAT=$JSONPLAT NODE4=$NODE4 NODE5=$NODE5 NODE_ROOT_DIR=$NODE_ROOT_DIR"
   - if [ -z ${NPM} ]; then mkdir build && cd build && cmake -DBUILDSWIGJAVA="$BUILDJAVA" -DBUILDARCH="$BUILDARCH" -DJSONPLAT=$JSONPLAT -DNODE_ROOT_DIR:PATH="${NVM_BIN}/.." -DCMAKE_INSTALL_PREFIX:PATH=../install -DSWIG_EXECUTABLE=/home/travis/bin/swig -DSWIG_DIR:PATH=/home/travis/share/swig/3.0.10/ .. && make install && make test; else mkdir build && cd build && cmake -DBUILDSWIGJAVA="$BUILDJAVA" -DJSONPLAT=$JSONPLAT -DNODE_ROOT_DIR:PATH="${NVM_BIN}/.." -DCMAKE_INSTALL_PREFIX:PATH=../install -DSWIG_EXECUTABLE=/home/travis/bin/swig -DSWIG_DIR:PATH=/home/travis/share/swig/3.0.10/ .. && make npmpkg && cd .. && ${NODE_GYP} configure && ${NODE_GYP} build; fi
   # simple test to see if we can load our node module
   - if [ ${NPM} ]; then cd build/Release/obj.target/ && node -e  "var m = require('./mraa.node'); m.getVersion()";fi

--- a/examples/javascript/AioA0.js
+++ b/examples/javascript/AioA0.js
@@ -22,11 +22,13 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var m = require('mraa'); //require mraa
-console.log('MRAA Version: ' + m.getVersion()); //write the mraa version to the console
+"use strict";
 
-var analogPin0 = new m.Aio(0); //setup access analog inpuput pin 0
-var analogValue = analogPin0.read(); //read the value of the analog pin
-var analogValueFloat = analogPin0.readFloat(); //read the pin value as a float
+const mraa = require('mraa'); //require mraa
+console.log('MRAA Version: ' + mraa.getVersion()); //write the mraa version to the console
+
+let analogPin0 = new mraa.Aio(0); //setup access analog inpuput pin 0
+let analogValue = analogPin0.read(); //read the value of the analog pin
+let analogValueFloat = analogPin0.readFloat(); //read the pin value as a float
 console.log(analogValue); //write the value of the analog pin to the console
 console.log(analogValueFloat.toFixed(5)); //write the value in the float format

--- a/examples/javascript/Blink-IO.js
+++ b/examples/javascript/Blink-IO.js
@@ -22,19 +22,18 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var m = require('mraa'); //require mraa
-console.log('MRAA Version: ' + m.getVersion()); //write the mraa version to the console
+"use strict";
 
-var myLed = new m.Gpio(13); //LED hooked up to digital pin 13 (or built in pin on Galileo Gen1 & Gen2)
-myLed.dir(m.DIR_OUT); //set the gpio direction to output
-var ledState = true; //Boolean to hold the state of Led
+const mraa = require('mraa'); //require mraa
+console.log('MRAA Version: ' + mraa.getVersion()); //write the mraa version to the console
 
-function periodicActivity()
-{
-  myLed.write(ledState?1:0); //if ledState is true then write a '1' (high) otherwise write a '0' (low)
-  ledState = !ledState; //invert the ledState
-  setTimeout(periodicActivity,1000); //call the indicated function after 1 second (1000 milliseconds)
+let myLed = new mraa.Gpio(13); //LED hooked up to digital pin 13 (or built in pin on Galileo Gen1 & Gen2)
+myLed.dir(mraa.DIR_OUT); //set the gpio direction to output
+let ledState = true; //Boolean to hold the state of Led
+
+function periodicActivity() {
+    myLed.write(ledState ? 1 : 0); //if ledState is true then write a '1' (high) otherwise write a '0' (low)
+    ledState = !ledState; //invert the ledState
 }
 
-periodicActivity(); //call the periodicActivity function
-
+setInterval(periodicActivity, 1000); //call the periodicActivity function every second

--- a/examples/javascript/GPIO_DigitalRead.js
+++ b/examples/javascript/GPIO_DigitalRead.js
@@ -22,17 +22,17 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var m = require('mraa'); //require mraa
-console.log('MRAA Version: ' + m.getVersion()); //write the mraa version to the console
+"use strict";
 
-var myDigitalPin = new m.Gpio(6); //setup digital read on pin 6
-myDigitalPin.dir(m.DIR_IN); //set the gpio direction to input
+const mraa = require('mraa'); //require mraa
+console.log('MRAA Version: ' + mraa.getVersion()); //write the mraa version to the console
 
-periodicActivity(); //call the periodicActivity function
+let myDigitalPin = new mraa.Gpio(6); //setup digital read on pin 6
+myDigitalPin.dir(mraa.DIR_IN); //set the gpio direction to input
 
-function periodicActivity() //
-{
-  var myDigitalValue =  myDigitalPin.read(); //read the digital value of the pin
-  console.log('Gpio is ' + myDigitalValue); //write the read value out to the console
-  setTimeout(periodicActivity,1000); //call the indicated function after 1 second (1000 milliseconds)
+function periodicActivity() {
+    let myDigitalValue = myDigitalPin.read(); //read the digital value of the pin
+    console.log('Gpio value is ' + myDigitalValue); //write the read value out to the console
 }
+
+setInterval(periodicActivity, 1000); //call the indicated function every 1 second (1000 milliseconds)

--- a/examples/javascript/GPIO_DigitalWrite.js
+++ b/examples/javascript/GPIO_DigitalWrite.js
@@ -22,9 +22,11 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var m = require('mraa'); //require mraa
-console.log('MRAA Version: ' + m.getVersion()); //write the mraa version to the console
+"use strict";
 
-var myDigitalPin = new m.Gpio(5); //setup digital read on pin 5
-myDigitalPin.dir(m.DIR_OUT); //set the gpio direction to output
+const mraa = require('mraa'); //require mraa
+console.log('MRAA Version: ' + mraa.getVersion()); //write the mraa version to the console
+
+let myDigitalPin = new mraa.Gpio(5); //setup digital read on pin 5
+myDigitalPin.dir(mraa.DIR_OUT); //set the gpio direction to output
 myDigitalPin.write(1); //set the digital pin to high (1)

--- a/examples/javascript/bmp85.js
+++ b/examples/javascript/bmp85.js
@@ -24,29 +24,32 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var m = require('mraa'); //require mraa
+"use strict";
 
-x = new m.I2c(0)
-x.address(0x77)
+const mraa = require('mraa'); //require mraa
+
+let i2cDevice = new mraa.I2c(0);
+i2cDevice.address(0x77);
 
 // initialise device
-if (x.readReg(0xd0) != 0x55) {
-  console.log("error");
+if (i2cDevice.readReg(0xd0) != 0x55) {
+    console.log("error");
 }
 
 // we want to read temperature so write 0x2e into control reg
-x.writeReg(0xf4, 0x2e)
+i2cDevice.writeReg(0xf4, 0x2e);
 
 // read a 16bit reg, obviously it's uncalibrated so mostly a useless value :)
-console.log(x.readWordReg(0xf6))
+console.log(i2cDevice.readWordReg(0xf6));
 
 // and we can do the same thing with the read()/write() calls if we wished
 // thought I'd really not recommend it!
-buf = new Buffer(2)
-buf[0] = 0xf4
-buf[1] = 0x2e
-console.log(buf.toString('hex'))
-x.write(buf)
+let buf = new Buffer(2);
+buf[0] = 0xf4;
+buf[1] = 0x2e;
+console.log(buf.toString('hex'));
+i2cDevice.write(buf);
 
-x.writeByte(0xf6)
-d = x.read(2)
+i2cDevice.writeByte(0xf6);
+let result = i2cDevice.read(2);
+console.log(result.toString('hex'));

--- a/examples/javascript/firmata.js
+++ b/examples/javascript/firmata.js
@@ -22,7 +22,9 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var mraa = require('mraa');
+"use strict";
+
+const mraa = require('mraa');
 console.log('MRAA Version: ' + mraa.getVersion());
 
 // open connection to firmata

--- a/examples/javascript/gpio-tool.js
+++ b/examples/javascript/gpio-tool.js
@@ -22,12 +22,14 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var mraa = require('mraa');
+"use strict";
+
+const mraa = require('mraa');
 const readline = require('readline');
 
 const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout
+    input: process.stdin,
+    output: process.stdout
 });
 
 function printUsage() {
@@ -42,16 +44,16 @@ function getVersion() {
 }
 
 function setPin() {
-    var pinNumber = arguments[0];
-    var pinValue = arguments[1];
-    var pin = new mraa.Gpio(pinNumber);
+    let pinNumber = arguments[0];
+    let pinValue = arguments[1];
+    let pin = new mraa.Gpio(pinNumber);
     pin.dir(mraa.DIR_OUT);
     pin.write(pinNumber, pinValue);
 }
 
 function getPin() {
-    var pinNumber = arguments[0];
-    var pin = new mraa.Gpio(pinNumber);
+    let pinNumber = arguments[0];
+    let pin = new mraa.Gpio(pinNumber);
     pin.dir(mraa.DIR_IN);
     console.log('Gpio ' + pinNumber + ' = ' + pin.read());
 }
@@ -61,9 +63,9 @@ function onPinLevelChange() {
 }
 
 function monitorPin() {
-    var pinNumber = arguments[0];
+    let pinNumber = arguments[0];
     try {
-        var pin = new mraa.Gpio(pinNumber);
+        let pin = new mraa.Gpio(pinNumber);
         pin.dir(mraa.DIR_IN);
         pin.isr(mraa.EDGE_BOTH, onPinLevelChange);
         rl.question('Press ENTER to stop', function(answer) {
@@ -71,37 +73,37 @@ function monitorPin() {
             pin.isrExit();
         });
     } catch (err) {
-     console.log(err.message);
+        console.log(err.message);
     }
 }
 
 const args = process.argv;
 const argc = args.length;
+
 if (argc >= 3) {
-    const cmd = args[2];
+    if (argc > 3) {
+        const pinNumber = parseInt(args[3]);
+    }
+
     switch (args[2]) {
-    case "version":
-        getVersion();
-        break;
-    case "get":
-        var pinNumber = parseInt(args[3]);
-        getPin(pinNumber);
-        break;
-    case "set":
-        var pinNumber = parseInt(args[3]);
-        var pinValue = parseInt(args[4]);
-        getPin(pinNumber, pinValue);
-        break;
-    case "monitor":
-        var pinNumber = parseInt(args[3]);
-        monitorPin(pinNumber);
-        break;
-    default:
-        console.log("Invalid command " + args[2]);
-        break;
+        case "version":
+            getVersion();
+            break;
+        case "get":
+            getPin(pinNumber);
+            break;
+        case "set":
+            let pinValue = parseInt(args[4]);
+            getPin(pinNumber, pinValue);
+            break;
+        case "monitor":
+            monitorPin(pinNumber);
+            break;
+        default:
+            console.log("Invalid command " + args[2]);
+            break;
     }
 } else {
     console.log("Command not specified");
     printUsage();
 }
-

--- a/examples/javascript/initio.js
+++ b/examples/javascript/initio.js
@@ -22,27 +22,29 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var m = require('mraa');
+"use strict";
+
+const mraa = require('mraa');
 
 // GPIO-PIN
-m.gpioFromDesc("gpio-1");
+mraa.gpioFromDesc("gpio-1");
 // GPIO-RAW-RAWPIN
-m.gpioFromDesc("gpio-raw-131");
+mraa.gpioFromDesc("gpio-raw-131");
 // AIO-PIN
-m.aioFromDesc("aio-1");
+mraa.aioFromDesc("aio-1");
 //PWM-PIN
-m.pwmFromDesc("pwm-6");
+mraa.pwmFromDesc("pwm-6");
 // PWM-RAW-CHIPID-PIN
-m.pwmFromDesc("pwm-raw-0-1")
+mraa.pwmFromDesc("pwm-raw-0-1")
 // UART-INDEX: the index is the one represented internally in the uart_dev array
-m.uartFromDesc("uart-0");
+mraa.uartFromDesc("uart-0");
 // UART-RAW-PATH
-m.uartFromDesc("uart-raw-/dev/ttyS0");
+mraa.uartFromDesc("uart-raw-/dev/ttyS0");
 // SPI-INDEX: same as UART
-m.spiFromDesc("spi-0");
+mraa.spiFromDesc("spi-0");
 // SPI-RAW-BUS-CS: USED to open and use /dev/spidev<BUS>.<CS>
-m.spiFromDesc("spi-raw-0-1");
+mraa.spiFromDesc("spi-raw-0-1");
 // I2C-INDEX: same as UART
-m.i2cFromDesc("i2c-0");
+mraa.i2cFromDesc("i2c-0");
 // I2C-RAW-BUS
-m.i2cFromDesc("i2c-raw-0");
+mraa.i2cFromDesc("i2c-raw-0");

--- a/examples/javascript/isr.js
+++ b/examples/javascript/isr.js
@@ -1,16 +1,18 @@
 #!/usr/bin/env node
 
-var m = require('mraa')
+"use strict";
 
-function h() {
-  console.log("HELLO!!!!")
+const mraa = require('mraa');
+
+function hello() {
+    console.log("HELLO!!!!");
 }
 
-x = new m.Gpio(14)
-x.isr(m.EDGE_BOTH, h)
+let pin = new mraa.Gpio(14);
+pin.isr(mraa.EDGE_BOTH, hello);
 
 setInterval(function() {
     // It's important to refer to our GPIO context here,
     // otherwise it will be garbage-collected
-    console.log("Waiting for an interrupt at GPIO pin " + x.getPin() + "...")
-}, 10000)
+    console.log("Waiting for an interrupt at GPIO pin " + pin.getPin() + "...");
+}, 10000);

--- a/examples/javascript/rgblcd.js
+++ b/examples/javascript/rgblcd.js
@@ -22,13 +22,15 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var m = require('mraa'); //require mraa
+"use strict";
 
-x = new m.I2c(0)
-x.address(0x62)
-x.writeReg(0, 0)
-x.writeReg(1, 0)
+const mraa = require('mraa'); //require mraa
 
-x.writeReg(0x08, 0xAA)
-x.writeReg(0x04, 255)
-x.writeReg(0x02, 255)
+let i2cDevice = new mraa.I2c(0);
+i2cDevice.address(0x62);
+i2cDevice.writeReg(0, 0);
+i2cDevice.writeReg(1, 0);
+
+i2cDevice.writeReg(0x08, 0xAA);
+i2cDevice.writeReg(0x04, 255);
+i2cDevice.writeReg(0x02, 255);

--- a/examples/javascript/spi.js
+++ b/examples/javascript/spi.js
@@ -24,15 +24,15 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var m = require('mraa'); //require mraa
+"use strict";
 
-x = new m.Spi(0)
-buf = new Buffer(4)
-buf[0] = 0xf4
-buf[1] = 0x2e
-buf[2] = 0x3e
-buf[3] = 0x4e
-buf2 = x.write(buf)
-console.log("Sent: " + buf.toString('hex') + ". Received: " + buf2.toString('hex'))
+const mraa = require('mraa'); //require mraa
 
-
+let spiDevice = new mraa.Spi(0);
+let buf = new Buffer(4);
+buf[0] = 0xf4;
+buf[1] = 0x2e;
+buf[2] = 0x3e;
+buf[3] = 0x4e;
+let buf2 = spiDevice.write(buf);
+console.log("Sent: " + buf.toString('hex') + ". Received: " + buf2.toString('hex'));

--- a/examples/javascript/uart.js
+++ b/examples/javascript/uart.js
@@ -22,33 +22,35 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var m = require('mraa'); //require mraa
-console.log('MRAA Version: ' + m.getVersion());
-u = new m.Uart(0)
+"use strict";
+
+const mraa = require('mraa'); //require mraa
+console.log('MRAA Version: ' + mraa.getVersion());
+let uart = new mraa.Uart(0);
 
 console.log("Note: connect Rx and Tx of UART with a wire before use");
 
 function sleep(delay) {
-  delay += new Date().getTime();
-  while (new Date() < delay) { }
+    delay += new Date().getTime();
+    while (new Date() < delay) {}
 }
 
 console.log("Set UART parameters");
 
-u.setBaudRate(115200);
-u.setMode(8, 0, 1);
-u.setFlowcontrol(false, false);
+uart.setBaudRate(115200);
+uart.setMode(8, 0, 1);
+uart.setFlowcontrol(false, false);
 sleep(200);
 
 console.log("First write-read circle:");
 
-u.writeStr("test\n");
+uart.writeStr("test\n");
 sleep(200);
-console.log(u.readStr(6));
+console.log(uart.readStr(6));
 sleep(200);
 
 console.log("Second write-read circle:");
 
-u.writeStr("2nd test\n");
+uart.writeStr("2nd test\n");
 sleep(200);
-console.log(u.readStr(10));
+console.log(uart.readStr(10));


### PR DESCRIPTION
Here goes the corrected version of PR #654, with my review comments addressed and some more fixes. Turned out on e.g. Edison additional "use strict" is required as Node.js version there is rather old and needs that. This shouldn't harm anyway and on newer version turns into no-op (it's enabled by default).