### PR TITLE
periphmraa: Fix PWM issues

### DIFF
--- a/include/mraa_adv_func.h
+++ b/include/mraa_adv_func.h
@@ -90,7 +90,6 @@ typedef struct {
     mraa_result_t (*pwm_init_pre) (int pin);
     mraa_result_t (*pwm_init_post) (mraa_pwm_context pwm);
     mraa_result_t (*pwm_period_replace) (mraa_pwm_context dev, int period);
-    mraa_result_t (*pwm_duty_cycle_replace) (mraa_pwm_context dev, int duty_cycle);
     float (*pwm_read_replace) (mraa_pwm_context dev);
     mraa_result_t (*pwm_write_replace) (mraa_pwm_context dev, float duty);
     mraa_result_t (*pwm_write_pre) (mraa_pwm_context dev, float percentage);

--- a/include/mraa_adv_func.h
+++ b/include/mraa_adv_func.h
@@ -86,6 +86,7 @@ typedef struct {
 
     mraa_pwm_context (*pwm_init_replace) (int pin);
     mraa_pwm_context (*pwm_init_internal_replace) (void* func_table, int pin);
+    mraa_result_t (*pwm_init_raw_replace) (mraa_pwm_context dev, int pin);
     mraa_result_t (*pwm_init_pre) (int pin);
     mraa_result_t (*pwm_init_post) (mraa_pwm_context pwm);
     mraa_result_t (*pwm_period_replace) (mraa_pwm_context dev, int period);

--- a/src/peripheralman/peripheralman.c
+++ b/src/peripheralman/peripheralman.c
@@ -68,14 +68,16 @@ mraa_pman_pwm_period_replace(mraa_pwm_context dev, int period)
 }
 
 static mraa_result_t
-mraa_pman_pwm_duty_cycle_replace(mraa_pwm_context dev, int duty_cycle)
+mraa_pman_pwm_write_replace(mraa_pwm_context dev, float duty)
 {
     if (!dev) {
         syslog(LOG_ERR, "pwm: stop: context is NULL");
         return 0;
     }
 
-    if (APwm_setDutyCycle(dev->bpwm, duty_cycle) != 0) {
+    // PIO can only take values between 0 <= duty <= 100
+    int d = (int) (duty > 100 ) ? 100 : duty;
+    if (APwm_setDutyCycle(dev->bpwm, d) != 0) {
         return 0;
     }
 
@@ -99,12 +101,6 @@ mraa_pman_pwm_enable_replace(mraa_pwm_context dev, int enable)
 
 static float
 mraa_pman_pwm_read_replace(mraa_pwm_context dev)
-{
-    return -MRAA_ERROR_FEATURE_NOT_SUPPORTED;
-}
-
-static mraa_result_t
-mraa_pman_pwm_write_replace(mraa_pwm_context dev, float duty)
 {
     return -MRAA_ERROR_FEATURE_NOT_SUPPORTED;
 }
@@ -867,7 +863,6 @@ mraa_peripheralman_plat_init()
 
     b->adv_func->pwm_init_raw_replace = &mraa_pman_pwm_init_raw_replace;
     b->adv_func->pwm_period_replace = &mraa_pman_pwm_period_replace;
-    b->adv_func->pwm_duty_cycle_replace = &mraa_pman_pwm_duty_cycle_replace;
     b->adv_func->pwm_enable_replace = &mraa_pman_pwm_enable_replace;
     b->adv_func->pwm_read_replace = &mraa_pman_pwm_read_replace;
     b->adv_func->pwm_write_replace = &mraa_pman_pwm_write_replace;

--- a/src/peripheralman/peripheralman.c
+++ b/src/peripheralman/peripheralman.c
@@ -782,7 +782,8 @@ mraa_peripheralman_plat_init()
     //Updating GPIO bus structure
     for (; i < gpios_count; i++) {
         b->pins[i].name = gpios[i];
-        b->pins[i].capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
+        //Retrieve this information from PIO once the API is available
+        b->pins[i].capabilities = (mraa_pincapabilities_t){ 1, 1, 1, 1, 1, 1, 1, 1 };
         b->pins[i].gpio.pinmap = i;
     }
 

--- a/src/peripheralman/peripheralman.c
+++ b/src/peripheralman/peripheralman.c
@@ -41,16 +41,15 @@ int uart_busses_count = 0;
 char **pwm_devices = NULL;
 int pwm_dev_count = 0;
 
-static mraa_pwm_context
-mraa_pman_pwm_init_replace(int pin)
+static mraa_result_t
+mraa_pman_pwm_init_raw_replace(mraa_pwm_context dev, int pin)
 {
-    mraa_pwm_context dev = (mraa_pwm_context) calloc(1, sizeof(struct _pwm));
     if (APeripheralManagerClient_openPwm(client, pwm_devices[pin], &dev->bpwm) != 0) {
         APwm_delete(dev->bpwm);
-        return NULL;
+        return MRAA_ERROR_INVALID_HANDLE;
     }
 
-    return dev;
+    return MRAA_SUCCESS;
 }
 
 static mraa_result_t
@@ -866,7 +865,7 @@ mraa_peripheralman_plat_init()
     b->adv_func->uart_write_replace = &mraa_pman_uart_write_replace;
     b->adv_func->uart_read_replace = &mraa_pman_uart_read_replace;
 
-    b->adv_func->pwm_init_replace = &mraa_pman_pwm_init_replace;
+    b->adv_func->pwm_init_raw_replace = &mraa_pman_pwm_init_raw_replace;
     b->adv_func->pwm_period_replace = &mraa_pman_pwm_period_replace;
     b->adv_func->pwm_duty_cycle_replace = &mraa_pman_pwm_duty_cycle_replace;
     b->adv_func->pwm_enable_replace = &mraa_pman_pwm_enable_replace;

--- a/src/pwm/pwm.c
+++ b/src/pwm/pwm.c
@@ -269,7 +269,12 @@ mraa_pwm_init(int pin)
         }
         return pret;
     }
+
+#if defined(PERIPHERALMAN)
+    return mraa_pwm_init_raw(chip, pin);
+#else
     return mraa_pwm_init_raw(chip, pinn);
+#endif
 }
 
 mraa_pwm_context


### PR DESCRIPTION
Update pin capabilities for each supported board.
Do it statically since there is no way to retrieve information
about the relationship between the pins gpio and alternate
functionality from peripheral manager.

Signed-off-by: Sanrio Alvares <sanrio.alvares@intel.com>