### PR TITLE
peripheralman: i2c_read_bytes_data returns length of read bytes

### DIFF
--- a/src/peripheralman/peripheralman.c
+++ b/src/peripheralman/peripheralman.c
@@ -499,9 +499,10 @@ mraa_pman_i2c_read_bytes_data_replace(mraa_i2c_context dev, uint8_t command, uin
         return -1;
     }
 
+    //TODO Replace with I2C_RDWR Ioctl from PIO when available since i2c_read_bytes_data expects length on success
     rc = AI2cDevice_readRegBuffer(dev->bi2c, command, data, length);
 
-    return rc;
+    return ((rc == 0)?length:rc);
 }
 
 static int


### PR DESCRIPTION
UPM expects length of read bytes. This is because MRAA does
the I2C_RDWR ioctl which returns number of bytes read.
PIO is yet to implement that API so currently does I2C_SMBUS
ioctl instead, which returns 0 in case of success.

Signed-off-by: Sanrio Alvares <sanrio.alvares@intel.com>