### PR TITLE
Joule.md: Added Interrupt Pin assignment information

### DIFF
--- a/docs/joule.md
+++ b/docs/joule.md
@@ -40,6 +40,9 @@ so only available UART is on the FTDI header. Disable the getty on ttyS2 and
 use mraa's uart raw mode to initialise on ttyS2. The Jumper J8 can be used to
 switch between using the FTDI 6 pin header and the micro USB output.
 
+**Interrupt** The following GPIO Pins are interrupt configurable: 1, 23, 25, 27, 
+29, 31, 33, 35, 51, 53, 55  
+
 Pin Mapping
 -----------
 


### PR DESCRIPTION
Verified that they worked with UBUNTU 16.04 LTS, Joule 570X, Tuchuck, BIOS #174, MRAA V1.5.1-24-g2ea6810

Setup: 
use
"#define CHECK_ALL_80_PINS_CONFIGURATION_STATUS  1" if you want to check which pins are interrupt "configurable"
If not defined, one "specified pin" can be tested with the interrupt handler
3 pin switch connected: to 1.8v J13.12 and GND J12.39, switch center pin connected to "Pin55" J13.15 in example below

Qt pseudo code:
init mraa()
call initIsrPins()

void myISR {
   static uint32_t myCnt = 0;
   qDebug("Interrupt GPIO!!!! %d\n", myCnt++);
}

void initIsrPins(void)
{
   mraa_result_t myStatus;
   uint8_t myPinNum = 1;

#ifdef CHECK_ALL_80_PINS_CONFIGURATION_STATUS
   for(myPinNum = 1; myPinNum <=80; myPinNum++)
   {
       mraa_gpio_context myIsr = mraa_gpio_init(myPinNum);
#else
       mraa_gpio_context myIsr = mraa_gpio_init(55);   // Manually enter Pin to test
#endif

       if(myIsr == 0)
           qDebug("FAILED mraa_gpio_context");
       else
       {
           myStatus = mraa_gpio_dir(myIsr, MRAA_GPIO_IN);
           if(myStatus != MRAA_SUCCESS)
               qDebug("FAILED mraa_gpio_dir");
           else
           {
               myStatus = mraa_gpio_isr(myIsr, MRAA_GPIO_EDGE_BOTH, (void (*)(void*)) myISR, NULL);
               if(myStatus != MRAA_SUCCESS)
                   qDebug("FAILED mraa_gpio_isr");
               else
                   qDebug("Passed:%d", myPinNum);
           }
       }
#ifdef CHECK_ALL_80_PINS_CONFIGURATION_STATUS
   }
}


for(;;) { };
}

Signed-off-by: Floyd Goldstein <floydg@softwareflair.com>