### PR TITLE
master/README.md: Add 96Boards option/link to ARM supported boards.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ ARM
 * [Banana Pi](../master/docs/banana_pi.md)
 * [Beaglebone Black](../master/docs/beaglebone.md)
 * [phyBOARD-Wega](../master/docs/phyboard-wega.md)
+* [96Boards](../master/docs/96boards.md)
 
 FPGA
 ----


### PR DESCRIPTION
Added 96Boards option to list of ARM supported boards
with relative link.

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>