### PR TITLE
uart: add a null pointer check before dereferencing plat->adv_func

### DIFF
--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -142,7 +142,7 @@ mraa_uart_init(int index)
         return NULL;
     }
 
-    if (plat->adv_func->uart_init_pre != NULL) {
+    if (plat->adv_func != NULL && plat->adv_func->uart_init_pre != NULL) {
         if (plat->adv_func->uart_init_pre(index) != MRAA_SUCCESS) {
             syslog(LOG_ERR, "uart%i: init: failure in pre-init platform hook", index);
             return NULL;


### PR DESCRIPTION
Please pull. It's one small bugfix to avoid segfaults in uart_init on basic platforms.

Signed-off-by: Tapani Utriainen <tapani@technexion.com>