### PR TITLE
Some stability fixes to prevent potential buffer overflows

### DIFF
--- a/examples/mraa-i2c.c
+++ b/examples/mraa-i2c.c
@@ -249,9 +249,11 @@ run_interactive_mode()
         if (strcmp(command, "q") == 0)
             return;
         char* str = strtok(command, " ");
+        int len = 0;
         while (str != NULL) {
-            arg = malloc(strlen(str) + 1);
-            argv[argc++] = strcpy(arg, str);
+            len = strlen(str) + 1;
+            arg = malloc(len);
+            argv[argc++] = strncpy(arg, str, len);
             str = strtok(NULL, " ");
         }
         process_command(argc, argv);

--- a/src/gpio/gpio.c
+++ b/src/gpio/gpio.c
@@ -248,7 +248,7 @@ mraa_gpio_interrupt_handler(void* arg)
     } else {
         // open gpio value with open(3)
         char bu[MAX_SIZE];
-        sprintf(bu, SYSFS_CLASS_GPIO "/gpio%d/value", dev->pin);
+        snprintf(bu, MAX_SIZE, SYSFS_CLASS_GPIO "/gpio%d/value", dev->pin);
         fp = open(bu, O_RDONLY);
         if (fp < 0) {
             syslog(LOG_ERR, "gpio%i: interrupt_handler: failed to open 'value' : %s", dev->pin, strerror(errno));

--- a/src/iio/iio.c
+++ b/src/iio/iio.c
@@ -355,7 +355,7 @@ mraa_iio_trigger_buffer(mraa_iio_context dev, void (*fptr)(char* data), void* ar
         return MRAA_ERROR_NO_RESOURCES;
     }
 
-    sprintf(bu, IIO_SLASH_DEV "%d", dev->num);
+    snprintf(bu, MAX_SIZE, IIO_SLASH_DEV "%d", dev->num);
     dev->fp = open(bu, O_RDONLY | O_NONBLOCK);
     if (dev->fp == -1) {
         return MRAA_ERROR_INVALID_RESOURCE;
@@ -505,7 +505,7 @@ mraa_iio_event_setup_callback(mraa_iio_context dev, void (*fptr)(struct iio_even
         return MRAA_ERROR_NO_RESOURCES;
     }
 
-    sprintf(bu, IIO_SLASH_DEV "%d", dev->num);
+    snprintf(bu, MAX_SIZE, IIO_SLASH_DEV "%d", dev->num);
     dev->fp = open(bu, O_RDONLY | O_NONBLOCK);
     if (dev->fp == -1) {
         return MRAA_ERROR_INVALID_RESOURCE;

--- a/src/pwm/pwm.c
+++ b/src/pwm/pwm.c
@@ -102,8 +102,8 @@ mraa_pwm_write_duty(mraa_pwm_context dev, int duty)
             return MRAA_ERROR_INVALID_RESOURCE;
         }
     }
-    char bu[64];
-    int length = sprintf(bu, "%d", duty);
+    char bu[MAX_SIZE];
+    int length = snprintf(bu, MAX_SIZE, "%d", duty);
     if (write(dev->duty_fp, bu, length * sizeof(char)) == -1)
     {
         syslog(LOG_ERR, "pwm%i write_duty: Failed to write to duty_cycle: %s", dev->pin, strerror(errno));

--- a/src/spi/spi.c
+++ b/src/spi/spi.c
@@ -157,7 +157,7 @@ mraa_spi_init_raw(unsigned int bus, unsigned int cs)
     }
 
     char path[MAX_SIZE];
-    sprintf(path, "/dev/spidev%u.%u", bus, cs);
+    snprintf(path, MAX_SIZE, "/dev/spidev%u.%u", bus, cs);
 
     dev->devfd = open(path, O_RDWR);
     if (dev->devfd < 0) {

--- a/src/x86/intel_edison_fab_c.c
+++ b/src/x86/intel_edison_fab_c.c
@@ -140,7 +140,7 @@ mraa_intel_edison_pinmode_change(int sysfs, int mode)
 
     mraa_result_t ret = MRAA_SUCCESS;
     char mode_buf[MAX_MODE_SIZE];
-    int length = sprintf(mode_buf, "%s%u", useDebugFS ? "mode" : "", mode);
+    int length = snprintf(mode_buf, MAX_MODE_SIZE, "%s%u", useDebugFS ? "mode" : "", mode);
     if (write(modef, mode_buf, length * sizeof(char)) == -1) {
         ret = MRAA_ERROR_INVALID_RESOURCE;
     }


### PR DESCRIPTION
Though unlikely in these specific pieces of code, it's an industry BKM to use `*n*` versions of `strcpy()` and `sprintf()` to avoid buffer overflows. We also use `*n*` ones across the board, so let's align these several outliers too.