### PR TITLE
mraa: clean up and bugfix by-name device lookup functions; add uart lookup function

### DIFF
--- a/api/mraa/common.h
+++ b/api/mraa/common.h
@@ -266,6 +266,14 @@ int mraa_spi_lookup(const char* spi_name);
 int mraa_pwm_lookup(const char* pwm_name);
 
 /**
+* Get UART index by name, board must be initialised.
+*
+* @param uart_name: Name of UART. Eg:UART1
+* @return int of MRAA index for UART, or -1 if not found.
+*/
+int mraa_uart_lookup(const char* uart_name);
+
+/**
  * Get default i2c bus, board must be initialised.
  *
  * @return int default i2c bus index

--- a/api/mraa/common.hpp
+++ b/api/mraa/common.hpp
@@ -301,6 +301,27 @@ getPwmLookup(std::string pwm_name)
 }
 
 /**
+* Get UART index by UART name, board must be initialised.
+*
+* @param pwm_name: Name of the UART. Eg: UART2
+* @throws std::invalid_argument if name is not found
+* @return MRAA index for the UART
+*/
+inline int
+getUartLookup(std::string uart_name)
+{
+    int index = mraa_uart_lookup(uart_name.c_str());
+
+    if (index < 0) {
+        std::ostringstream oss;
+        oss << "UART name " << uart_name << " is not valid";
+        throw std::invalid_argument(oss.str());
+    }
+
+    return index;
+}
+
+/**
  * Sets the log level to use from 0-7 where 7 is very verbose. These are the
  * syslog log levels, see syslog(3) for more information on the levels.
  *

--- a/src/mraa.c
+++ b/src/mraa.c
@@ -904,6 +904,27 @@ mraa_pwm_lookup(const char* pwm_name)
 }
 
 int
+mraa_uart_lookup(const char* uart_name)
+{
+    int i;
+
+    if (plat == NULL) {
+        return -1;
+    }
+
+    if (uart_name == NULL || strlen(uart_name) == 0) {
+        return -1;
+    }
+
+    for (i = 0; i < plat->uart_dev_count; i++) {
+         if (plat->uart_dev[i].name != NULL && strcmp(uart_name, plat->uart_dev[i].name) == 0) {
+             return plat->uart_dev[i].index;
+         }
+    }
+    return -1;
+}
+
+int
 mraa_get_default_i2c_bus(uint8_t platform_offset)
 {
     if (plat == NULL)

--- a/src/mraa.c
+++ b/src/mraa.c
@@ -828,12 +828,12 @@ mraa_gpio_lookup(const char* pin_name)
         return -1;
     }
 
-    if (strlen(pin_name) == 0) {
+    if (pin_name == NULL || strlen(pin_name) == 0) {
         return -1;
     }
 
     for (i = 0; i < plat->gpio_count; i++) {
-         if (strcmp(pin_name, plat->pins[i].name) == 0) {
+         if (plat->pins[i].name != NULL && strcmp(pin_name, plat->pins[i].name) == 0) {
              return plat->pins[i].gpio.pinmap;
          }
     }
@@ -849,12 +849,12 @@ mraa_i2c_lookup(const char* i2c_name)
         return -1;
     }
 
-    if (strlen(i2c_name) == 0) {
+    if (i2c_name == NULL || strlen(i2c_name) == 0) {
         return -1;
     }
 
     for (i = 0; i < plat->i2c_bus_count; i++) {
-         if (strcmp(i2c_name, plat->i2c_bus[i].name) == 0) {
+         if (plat->i2c_bus[i].name != NULL && strcmp(i2c_name, plat->i2c_bus[i].name) == 0) {
              return plat->i2c_bus[i].bus_id;
          }
     }
@@ -870,12 +870,12 @@ mraa_spi_lookup(const char* spi_name)
         return -1;
     }
 
-    if (strlen(spi_name) == 0) {
+    if (spi_name == NULL || strlen(spi_name) == 0) {
         return -1;
     }
 
     for (i = 0; i < plat->spi_bus_count; i++) {
-         if (strcmp(spi_name, plat->spi_bus[i].name) == 0) {
+         if (plat->spi_bus[i].name != NULL && strcmp(spi_name, plat->spi_bus[i].name) == 0) {
              return plat->spi_bus[i].bus_id;
          }
     }
@@ -891,12 +891,12 @@ mraa_pwm_lookup(const char* pwm_name)
         return -1;
     }
 
-    if (strlen(pwm_name) == 0) {
+    if (pwm_name == NULL || strlen(pwm_name) == 0) {
         return -1;
     }
 
     for (i = 0; i < plat->pwm_dev_count; i++) {
-         if (strcmp(pwm_name, plat->pwm_dev[i].name) == 0) {
+         if (plat->pwm_dev[i].name != NULL && strcmp(pwm_name, plat->pwm_dev[i].name) == 0) {
              return plat->pwm_dev[i].index;
          }
     }

--- a/src/mraa.c
+++ b/src/mraa.c
@@ -819,8 +819,11 @@ mraa_get_pin_name(int pin)
     return (char*) current_plat->pins[pin].name;
 }
 
-int mraa_gpio_lookup(const char* pin_name)
+int
+mraa_gpio_lookup(const char* pin_name)
 {
+    int i;
+
     if (plat == NULL) {
         return -1;
     }
@@ -829,17 +832,19 @@ int mraa_gpio_lookup(const char* pin_name)
         return -1;
     }
 
-    int i = 0;
-    for (; i < plat->gpio_count; i++) {
-         if (0 == strcmp(pin_name, plat->pins[i].name)) {
+    for (i = 0; i < plat->gpio_count; i++) {
+         if (strcmp(pin_name, plat->pins[i].name) == 0) {
              return plat->pins[i].gpio.pinmap;
          }
     }
     return -1;
 }
 
-int mraa_i2c_lookup(const char* i2c_name)
+int
+mraa_i2c_lookup(const char* i2c_name)
 {
+    int i;
+
     if (plat == NULL) {
         return -1;
     }
@@ -848,17 +853,19 @@ int mraa_i2c_lookup(const char* i2c_name)
         return -1;
     }
 
-    int i = 0;
-    for (; i < plat->i2c_bus_count; i++) {
-         if (0 == strcmp(i2c_name, plat->i2c_bus[i].name)) {
+    for (i = 0; i < plat->i2c_bus_count; i++) {
+         if (strcmp(i2c_name, plat->i2c_bus[i].name) == 0) {
              return plat->i2c_bus[i].bus_id;
          }
     }
     return -1;
 }
 
-int mraa_spi_lookup(const char* spi_name)
+int
+mraa_spi_lookup(const char* spi_name)
 {
+    int i;
+
     if (plat == NULL) {
         return -1;
     }
@@ -867,17 +874,19 @@ int mraa_spi_lookup(const char* spi_name)
         return -1;
     }
 
-    int i = 0;
-    for (; i < plat->spi_bus_count; i++) {
-         if (0 == strcmp(spi_name, plat->spi_bus[i].name)) {
+    for (i = 0; i < plat->spi_bus_count; i++) {
+         if (strcmp(spi_name, plat->spi_bus[i].name) == 0) {
              return plat->spi_bus[i].bus_id;
          }
     }
     return -1;
 }
 
-int mraa_pwm_lookup(const char* pwm_name)
+int
+mraa_pwm_lookup(const char* pwm_name)
 {
+    int i;
+
     if (plat == NULL) {
         return -1;
     }
@@ -886,9 +895,8 @@ int mraa_pwm_lookup(const char* pwm_name)
         return -1;
     }
 
-    int i = 0;
-    for (; i < plat->pwm_dev_count; i++) {
-         if (0 == strcmp(pwm_name, plat->pwm_dev[i].name)) {
+    for (i = 0; i < plat->pwm_dev_count; i++) {
+         if (strcmp(pwm_name, plat->pwm_dev[i].name) == 0) {
              return plat->pwm_dev[i].index;
          }
     }


### PR DESCRIPTION
PR 707 introduced new and useful functions to look-up devices using a text string instead of index.
There are three patches in this PR related to these functions.

Patch 1. Adapts the style in some of the functions introduced by PR707 to match the rest of the codebase (like return type on a separate line). No functional changes.
Patch 2. Fixes potential null pointer errors on platforms where ever bus/device/pin is not named, or when a null pointer is passed as argument (user error).
Patch 3. Introduces a similar function to look up UARTs by name. Somehow UART lookup was omitted in the earlier patches.
