### PR TITLE
Replace strcmp() with strncmp()

### DIFF
--- a/examples/mraa-i2c.c
+++ b/examples/mraa-i2c.c
@@ -166,16 +166,16 @@ int
 process_command(int argc, char** argv)
 {
     int status = 0;
-    if (strcmp(argv[1], "help") == 0) {
+    if (strncmp(argv[1], "help", strlen("help") + 1) == 0) {
         print_help();
         return 0;
-    } else if (strcmp(argv[1], "version") == 0) {
+    } else if (strncmp(argv[1], "version", strlen("version") + 1) == 0) {
         print_version();
         return 0;
-    } else if (strcmp(argv[1], "list") == 0) {
+    } else if (strncmp(argv[1], "list", strlen("list") + 1) == 0) {
         print_busses();
         return 0;
-    } else if (strcmp(argv[1], "detect") == 0) {
+    } else if (strncmp(argv[1], "detect", strlen("detect") + 1) == 0) {
         if (argc == 3) {
             int bus = strtol(argv[2], NULL, 0);
             i2c_detect_devices(bus);
@@ -184,10 +184,11 @@ process_command(int argc, char** argv)
             print_command_error();
             return 1;
         }
-    } else if ((strcmp(argv[1], "get") == 0) || (strcmp(argv[1], "getrpt") == 0)) {
+    } else if ((strncmp(argv[1], "get", strlen("get") + 1) == 0) ||
+               (strncmp(argv[1], "getrpt", strlen("getrpt") + 1) == 0)) {
         if (argc == 5) {
             int interation = 0;
-            mraa_boolean_t should_repeat = strcmp(argv[1], "getrpt") == 0;
+            mraa_boolean_t should_repeat = strncmp(argv[1], "getrpt", strlen("getrpt") + 1) == 0;
             int bus = strtol(argv[2], NULL, 0);
             uint8_t device_address = strtol(argv[3], NULL, 0);
             uint8_t register_address = strtol(argv[4], NULL, 0);
@@ -211,7 +212,7 @@ process_command(int argc, char** argv)
             status = 1;
         }
         return status;
-    } else if ((strcmp(argv[1], "set") == 0)) {
+    } else if ((strncmp(argv[1], "set", strlen("set") + 1) == 0)) {
         if (argc == 6) {
             int bus = strtol(argv[2], NULL, 0);
             uint8_t device_address = strtol(argv[3], NULL, 0);
@@ -246,7 +247,7 @@ run_interactive_mode()
         fprintf(stdout, "Command: ");
         fgets(command, 80, stdin);
         command[strlen(command) - 1] = 0;
-        if (strcmp(command, "q") == 0)
+        if (strncmp(command, "q", strlen("q") + 1) == 0)
             return;
         char* str = strtok(command, " ");
         int len = 0;

--- a/src/mraa.c
+++ b/src/mraa.c
@@ -833,7 +833,8 @@ mraa_gpio_lookup(const char* pin_name)
     }
 
     for (i = 0; i < plat->gpio_count; i++) {
-         if (plat->pins[i].name != NULL && strcmp(pin_name, plat->pins[i].name) == 0) {
+         if (plat->pins[i].name != NULL &&
+             strncmp(pin_name, plat->pins[i].name, strlen(plat->pins[i].name) + 1) == 0) {
              return plat->pins[i].gpio.pinmap;
          }
     }
@@ -854,7 +855,8 @@ mraa_i2c_lookup(const char* i2c_name)
     }
 
     for (i = 0; i < plat->i2c_bus_count; i++) {
-         if (plat->i2c_bus[i].name != NULL && strcmp(i2c_name, plat->i2c_bus[i].name) == 0) {
+         if (plat->i2c_bus[i].name != NULL &&
+             strncmp(i2c_name, plat->i2c_bus[i].name, strlen(plat->i2c_bus[i].name) + 1) == 0) {
              return plat->i2c_bus[i].bus_id;
          }
     }
@@ -875,7 +877,8 @@ mraa_spi_lookup(const char* spi_name)
     }
 
     for (i = 0; i < plat->spi_bus_count; i++) {
-         if (plat->spi_bus[i].name != NULL && strcmp(spi_name, plat->spi_bus[i].name) == 0) {
+         if (plat->spi_bus[i].name != NULL &&
+             strncmp(spi_name, plat->spi_bus[i].name, strlen(plat->spi_bus[i].name) + 1) == 0) {
              return plat->spi_bus[i].bus_id;
          }
     }
@@ -896,7 +899,8 @@ mraa_pwm_lookup(const char* pwm_name)
     }
 
     for (i = 0; i < plat->pwm_dev_count; i++) {
-         if (plat->pwm_dev[i].name != NULL && strcmp(pwm_name, plat->pwm_dev[i].name) == 0) {
+         if (plat->pwm_dev[i].name != NULL &&
+             strncmp(pwm_name, plat->pwm_dev[i].name, strlen(plat->pwm_dev[i].name) + 1) == 0) {
              return plat->pwm_dev[i].index;
          }
     }
@@ -917,7 +921,8 @@ mraa_uart_lookup(const char* uart_name)
     }
 
     for (i = 0; i < plat->uart_dev_count; i++) {
-         if (plat->uart_dev[i].name != NULL && strcmp(uart_name, plat->uart_dev[i].name) == 0) {
+         if (plat->uart_dev[i].name != NULL &&
+             strncmp(uart_name, plat->uart_dev[i].name, strlen(plat->uart_dev[i].name) + 1) == 0) {
              return plat->uart_dev[i].index;
          }
     }
@@ -1311,11 +1316,11 @@ mraa_add_from_lockfile(const char* imraa_lock_file)
         for (i = 0; i < subplat_num; i++) {
             struct json_object *ioobj = json_object_array_get_idx(ioarray, i);
             json_object_object_foreach(ioobj, key, val) {
-                if (strcmp(key, "id") == 0) {
+                if (strncmp(key, "id", strlen("id") + 1) == 0) {
                     if (mraa_atoi(json_object_get_string(val), &id) != MRAA_SUCCESS) {
                         id = -1;
                     }
-                } else if (strcmp(key, "uart") == 0) {
+                } else if (strncmp(key, "uart", strlen("uart") + 1) == 0) {
                     uartdev = json_object_get_string(val);
                 }
             }


### PR DESCRIPTION
This is for #731. Arguably in some of the cases we don't really need `*n*` version (string literals) or just trade one potential segmentation fault (from unbound `strcmp()`) to another (from unbound `strlen()` - `strnlen()` would probably be an answer here, but I'm not sure we want to go down that path).

But even if the above holds, it still makes sense from the code unification standpoint - we use `strncmp()` everywhere else.

Side note - I've noticed in most of the cases we use `strncmp()`, we are actually doing a substring comparisons (i.e. without a null-terminator taken into account). While this apparently works ok - as no one complained so far and nothing broke - I could go over and replace that with exact match checks. Let me know what you think about that.