### PR TITLE
UART speed related additions/fixes

### DIFF
--- a/api/mraa/common.h
+++ b/api/mraa/common.h
@@ -202,6 +202,13 @@ int mraa_get_platform_combined_type();
 unsigned int mraa_get_pin_count();
 
 /**
+ * Get the number of usable UARTs, board must be initialised.
+ *
+ * @return number of usable UARTs on the platform, returns -1 on failure.
+ */
+int mraa_get_uart_count(void);
+
+/**
  * Get platform usable I2C bus count, board must be initialised.
  *
  * @return number f usable I2C bus count on the current platform. Function will

--- a/api/mraa/common.hpp
+++ b/api/mraa/common.hpp
@@ -179,6 +179,18 @@ getPinCount()
 }
 
 /**
+ * Get platform usable UART count, board must be initialised.
+ *
+ * @return number of usable UARTs on the current platform. Function will
+ * return -1 on failure
+ */
+inline int
+getUartCount()
+{
+    return mraa_get_uart_count();
+}
+
+/**
  * Get platform usable I2C bus count, board must be initialised.
  *
  * @return number f usable I2C bus count on the current platform. Function will

--- a/src/mraa.c
+++ b/src/mraa.c
@@ -751,6 +751,15 @@ mraa_get_platform_version(int platform_offset)
 }
 
 int
+mraa_get_uart_count(void)
+{
+    if (plat == NULL) {
+        return -1;
+    }
+    return plat->uart_dev_count;
+}
+
+int
 mraa_get_i2c_bus_count()
 {
     if (plat == NULL) {

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -110,7 +110,7 @@ uint2speed(unsigned int speed)
 #endif
         default:
             // if we are here, then an unsupported baudrate was selected.
-            return 0;
+            return B0;
     }
 }
 
@@ -412,7 +412,7 @@ mraa_uart_set_baudrate(mraa_uart_context dev, unsigned int baud)
 
     // set our baud rates
     speed_t speed = uint2speed(baud);
-    if (speed == 0)
+    if (speed == B0)
     {
         syslog(LOG_ERR, "uart%i: set_baudrate: invalid baudrate: %i", dev->index, baud);
         return MRAA_ERROR_INVALID_PARAMETER;

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -114,6 +114,54 @@ uint2speed(unsigned int speed)
     }
 }
 
+static unsigned int speed_to_uint(speed_t speedt) {
+    struct baud_table {
+        speed_t speedt;
+        unsigned int baudrate;
+    };
+    static const struct baud_table bauds[] = {
+        { B50, 50 },
+        { B75, 75 },
+        { B110, 110 },
+        { B150, 150 },
+        { B200, 200 },
+        { B300, 300 },
+        { B600, 600 },
+        { B1200, 1200 },
+        { B1800, 1800 },
+        { B2400, 2400 },
+        { B9600, 9600 },
+        { B19200, 19200 },
+        { B38400, 38400 },
+        { B57600, 57600 },
+        { B115200, 115200 },
+        { B230400, 230400 },
+        { B460800, 460800 },
+        { B500000, 500000 },
+        { B576000, 576000 },
+        { B921600, 921600 },
+        { B1000000, 1000000 },
+        { B1152000, 1152000 },
+        { B1500000, 1500000 },
+        { B2000000, 2000000 },
+        { B2500000, 2500000 },
+        { B3000000, 3000000 },
+#if !defined(MSYS)
+        { B3500000, 3500000 },
+        { B4000000, 4000000 },
+#endif
+        { B0, 0} /* Must be last in this table */
+    };
+    int i = 0;
+
+    while (bauds[i].baudrate > 0) {
+        if (speedt == bauds[i].speedt)
+            return bauds[i].baudrate;
+        i++;
+    }
+    return 0;
+}
+
 static mraa_uart_context
 mraa_uart_init_internal(mraa_adv_func_t* func_table)
 {


### PR DESCRIPTION
This PR involves three patches, nothing major.

1. A function that converts a `speed_t` to integer baudrate (code using this function is not-yet commited).
2. `uint2speed()` function would not always return a `speed_t`, but the `int` constant 0. Changed that to the `speed_t` equivalent. This patch has probably no functional changes.
3. A function that returns the number of available UARTs 

There are two discussion points regarding patch 3.

1. Is there a reason for lack of similar accessor functions for other pins/buses (like gpio, spi, pwm ...)? Maybe there is a design goal to keep the interfaces small and not cluttered with too many functions? Or just nobody got around writing them? In the latter case, I have similar patches ready to be pushed for accessing other board items.
2. My 3rd patch also violates what appears to be a style standard in the framework. Instead of just declaring the function, I also provide a prototype for it. Maybe there is a reason for the lack of prototypes for functions of zero arity? (Esthetical? Not realizing the difference declaration and prototype?). The later C standards (C99 and onwards) strongly discourage the use of declarations the way they are used here (as far as I remember...).

So before I push more patches, it would be good if there is a hint about which way to go. 