### PR TITLE
Code analysis findings - next part

### DIFF
--- a/src/aio/aio.c
+++ b/src/aio/aio.c
@@ -37,6 +37,11 @@ static int raw_bits;
 static mraa_result_t
 aio_get_valid_fp(mraa_aio_context dev)
 {
+    if (dev == NULL) {
+        syslog(LOG_ERR, "aio: get_valid_fp: context is invalid");
+        return MRAA_ERROR_INVALID_HANDLE;
+    }
+
     if (IS_FUNC_DEFINED(dev, aio_get_valid_fp)) {
         return dev->advance_func->aio_get_valid_fp(dev);
     }

--- a/src/gpio/gpio.c
+++ b/src/gpio/gpio.c
@@ -238,6 +238,11 @@ mraa_gpio_wait_interrupt(int fd
 static void*
 mraa_gpio_interrupt_handler(void* arg)
 {
+    if (arg == NULL) {
+        syslog(LOG_ERR, "gpio: interrupt_handler: context is invalid");
+        return NULL;
+    }
+
     mraa_gpio_context dev = (mraa_gpio_context) arg;
     int fp = -1;
     mraa_result_t ret;

--- a/src/iio/iio.c
+++ b/src/iio/iio.c
@@ -465,7 +465,7 @@ mraa_iio_event_poll(mraa_iio_context dev, struct iio_event_data* data)
     if (ret == -1 || event_fd == -1)
         return MRAA_ERROR_UNSPECIFIED;
 
-    ret = read(event_fd, data, sizeof(struct iio_event_data));
+    read(event_fd, data, sizeof(struct iio_event_data));
 
     close(event_fd);
     return MRAA_SUCCESS;

--- a/src/json/jsonplatform.c
+++ b/src/json/jsonplatform.c
@@ -95,8 +95,8 @@ mraa_init_json_platform_platform(json_object* jobj_platform, mraa_board_t* board
             syslog(LOG_ERR, "init_json_platform: Empty string provided for \"%s\" key in platform", NAME_KEY);
             return MRAA_ERROR_NO_DATA_AVAILABLE;
         }
-        board->platform_name = (char*) calloc(length, sizeof(char));
-        strncpy(board->platform_name, temp_string, length);
+        board->platform_name = (char*) calloc(length + 1, sizeof(char));
+        strncpy(board->platform_name, temp_string, length + 1);
     } else {
         syslog(LOG_ERR, "init_json_platform: No \"%s\" key in platform", NAME_KEY);
         return MRAA_ERROR_NO_DATA_AVAILABLE;
@@ -299,7 +299,7 @@ mraa_init_json_platform_i2c(json_object* jobj_i2c, mraa_board_t* board, int inde
     }
     // Get the bus number (e.g. 2 for /dev/i2c-2). If it doesn't exist, default to bus = pos
     bus = pos;
-    ret = mraa_init_json_platform_get_pin(jobj_i2c, I2C_KEY, BUS_KEY, index, &bus);
+    mraa_init_json_platform_get_pin(jobj_i2c, I2C_KEY, BUS_KEY, index, &bus);
     // Setup the sda pin
     ret = mraa_init_json_platform_get_index(jobj_i2c, I2C_KEY, SDAPIN_KEY, index, &pin,
                                             board->phy_pin_count - 1);
@@ -521,8 +521,8 @@ mraa_init_json_platform_uart(json_object* jobj_uart, mraa_board_t* board, int in
             syslog(LOG_ERR, "init_json_platform: UART Path at index: %d was empty", index);
             return MRAA_ERROR_NO_DATA_AVAILABLE;
         }
-        board->uart_dev[pos].device_path = (char*) calloc(length, sizeof(char));
-        strncpy(board->uart_dev[pos].device_path, temp_string, length);
+        board->uart_dev[pos].device_path = (char*) calloc(length + 1, sizeof(char));
+        strncpy(board->uart_dev[pos].device_path, temp_string, length + 1);
     } else {
         syslog(LOG_ERR, "init_json_platform: UART config at index: %d needs a path", index);
         return MRAA_ERROR_NO_DATA_AVAILABLE;


### PR DESCRIPTION
Here goes the next part of fixes for static code analysis findings (+some of my own, not flagged by the scanner).

@arfoll, I remember you've suggested I do it just in one big commit to make it easier, but I'm really ok with splitting it to smaller ones and I think that would make it easier to analyze/revert in case that's necessary. I aim for something like one commit per-file or a group of files (like examples), depending on the number and nature of fixes.