### PR TITLE
Fix Travis execution for gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,12 @@ matrix:
 services:
   - docker
 
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/1.9.0/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
 before_script:
   - if [ "$CC" == "gcc" ]; then export CC=gcc-4.8; fi
   - if [ "$CXX" == "g++" ]; then export CXX=g++-4.8; fi

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 
 services:
 
@@ -10,27 +10,27 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
-        - BUILDDOC=OFF
-        - BUILDSWIG=OFF
-        - BUILDSWIGPYTHON=OFF
-        - BUILDSWIGJAVA=OFF
-        - BUILDSWIGNODE=OFF
-        - USBPLAT=OFF
-        - FIRMATA=OFF
-        - ONEWIRE=OFF
-        - JSONPLAT
-        - IMRAA=OFF
-        - FTDI4222=OFF
-        - IPK=OFF
-        - RPM=OFF
-        - ENABLEEXAMPLES=ON
-        - INSTALLGPIOTOOL=OFF
-        - INSTALLTOOLS=OFF
-        - BUILDTESTS=ON
-        - CC=clang-3.8
-        - CXX=clang++-3.8
-        - NODE_VERSION=v4.4.7
-        - BUILDARCH
+        - BUILDDOC=${BUILDDOC:-OFF}
+        - BUILDSWIG=${BUILDSWIG:-OFF}
+        - BUILDSWIGPYTHON=${BUILDSWIGPYTHON:-OFF}
+        - BUILDSWIGJAVA=${BUILDSWIGJAVA:-OFF}
+        - BUILDSWIGNODE=${BUILDSWIGNODE:-OFF}
+        - USBPLAT=${USBPLAT:-OFF}
+        - FIRMATA=${FIRMATA:-OFF}
+        - ONEWIRE=${ONEWIRE:-OFF}
+        - JSONPLAT=${JSONPLAT:-OFF}
+        - IMRAA=${IMRAA:-OFF}
+        - FTDI4222=${FTDI4222:-OFF}
+        - IPK=${IPK:-OFF}
+        - RPM=${RPM:-OFF}
+        - ENABLEEXAMPLES=${ENABLEEXAMPLES:-ON}
+        - INSTALLGPIOTOOL=${INSTALLGPIOTOOL:-OFF}
+        - INSTALLTOOLS=${INSTALLTOOLS:-OFF}
+        - BUILDTESTS${BUILDTESTS:-ON}
+        - CC=${CC:-clang-3.8}
+        - CXX=${CXX:-clang++-3.8}
+        - NODE_VERSION=${NODE_VERSION:-v4.4.7}
+        - BUILDARCH=${BUILDARCH}
     environment:
       - http_proxy
       - https_proxy
@@ -42,8 +42,6 @@ services:
       args:
         - BUILDDOC=ON
     command: bash -c "make doc"
-    volumes:
-      - ./build/html:/usr/src/app/build/html
 
   python2:
     extends: main

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
         - ENABLEEXAMPLES=${ENABLEEXAMPLES:-ON}
         - INSTALLGPIOTOOL=${INSTALLGPIOTOOL:-OFF}
         - INSTALLTOOLS=${INSTALLTOOLS:-OFF}
-        - BUILDTESTS${BUILDTESTS:-ON}
+        - BUILDTESTS=${BUILDTESTS:-ON}
         - CC=${CC:-clang-3.8}
         - CXX=${CXX:-clang++-3.8}
         - NODE_VERSION=${NODE_VERSION:-v4.4.7}


### PR DESCRIPTION
Travis was only executing jobs with clang compiler, because the CC and CXX value was hardcoded in the docker-compose.yaml file. This new syntax allow to load the value from the execution environment, or set a default if no value is found