### PR TITLE
gpio : Add support for input pull up/down modes

### DIFF
--- a/api/mraa/gpio.h
+++ b/api/mraa/gpio.h
@@ -85,6 +85,14 @@ typedef enum {
 } mraa_gpio_edge_t;
 
 /**
+ * Gpio input modes
+ */
+typedef enum {
+    MRAA_GPIO_ACTIVE_HIGH = 0, /**< Resistive High */
+    MRAA_GPIO_ACTIVE_LOW = 1,  /**< Resistive Low */
+} mraa_gpio_input_mode_t;
+
+/**
  * Initialise gpio_context, based on board number
  *
  *  @param pin Pin number read from the board, i.e IO3 is 3
@@ -217,6 +225,16 @@ int mraa_gpio_get_pin(mraa_gpio_context dev);
  * @return gpio number
  */
 int mraa_gpio_get_pin_raw(mraa_gpio_context dev);
+
+/**
+ * Set Gpio input mode
+ *
+ * @param dev The Gpio context
+ * @param mode Mode to set input pin state
+ * @return Result of operation
+ */
+mraa_result_t mraa_gpio_input_mode(mraa_gpio_context dev, mraa_gpio_input_mode_t);
+
 
 #ifdef __cplusplus
 }

--- a/api/mraa/gpio.hpp
+++ b/api/mraa/gpio.hpp
@@ -70,6 +70,14 @@ typedef enum {
 } Edge;
 
 /**
+ * Gpio Input modes
+ */
+typedef enum {
+    MODE_IN_ACTIVE_HIGH = 0, /**< Resistive High */
+    MODE_IN_ACTIVE_LOW = 1,  /**< Resistive Low */
+} InputMode;
+
+/**
  * @brief API to General Purpose IO
  *
  * This file defines the gpio interface for libmraa
@@ -315,6 +323,19 @@ class Gpio
         }
         return mraa_gpio_get_pin(m_gpio);
     }
+
+    /**
+     * Change Gpio input mode
+     *
+     * @param mode The mode to change the gpio input
+     * @return Result of operation
+     */
+    Result
+    inputMode(InputMode mode)
+    {
+        return (Result )mraa_gpio_input_mode(m_gpio, (mraa_gpio_input_mode_t) mode);
+    }
+
 
   private:
     mraa_gpio_context m_gpio;

--- a/src/gpio/gpio.c
+++ b/src/gpio/gpio.c
@@ -839,3 +839,45 @@ mraa_gpio_get_pin_raw(mraa_gpio_context dev)
     }
     return dev->pin;
 }
+
+mraa_result_t
+mraa_gpio_input_mode(mraa_gpio_context dev, mraa_gpio_input_mode_t mode)
+{
+    if (dev == NULL) {
+        syslog(LOG_ERR, "gpio: in_mode: context is invalid");
+        return MRAA_ERROR_INVALID_HANDLE;
+    }
+
+    char filepath[MAX_SIZE];
+    snprintf(filepath, MAX_SIZE, SYSFS_CLASS_GPIO "/gpio%d/active_low", dev->pin);
+
+    int active_low = open(filepath, O_WRONLY);
+    if (active_low == -1) {
+        syslog(LOG_ERR, "gpio%i: mode: Failed to open 'active_low' for writing: %s", dev->pin, strerror(errno));
+        return MRAA_ERROR_INVALID_RESOURCE;
+    }
+
+    char bu[MAX_SIZE];
+    int length;
+    switch (mode) {
+        case MRAA_GPIO_ACTIVE_HIGH:
+            length = snprintf(bu, sizeof(bu), "%d", 0);
+            break;
+        case MRAA_GPIO_ACTIVE_LOW:
+            length = snprintf(bu, sizeof(bu), "%d", 1);
+            break;
+        default:
+            close(active_low);
+            return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
+    }
+
+    if (write(active_low, bu, length * sizeof(char)) == -1) {
+        syslog(LOG_ERR, "gpio%i: mode: Failed to write to 'active_low': %s", dev->pin, strerror(errno));
+        close(active_low);
+        return MRAA_ERROR_INVALID_RESOURCE;
+    }
+
+    close(active_low);
+
+    return MRAA_SUCCESS;
+}


### PR DESCRIPTION
Make use of 'active_low' interface in sysfs for configuring input pin
in pull up / pull down mode. C++ binding also has been added.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>