### PR TITLE
intel_edison_fab: enable support for vanilla kernels >= 4 for serial

### DIFF
--- a/src/x86/intel_edison_fab_c.c
+++ b/src/x86/intel_edison_fab_c.c
@@ -31,6 +31,7 @@
 #include <linux/spi/spidev.h>
 #include <errno.h>
 #include <time.h>
+#include <sys/utsname.h>
 
 #include "common.h"
 #include "x86/intel_edison_fab_c.h"
@@ -45,7 +46,7 @@
 // Might not always be correct. First thing to check if mmap stops
 // working. Check the device for 0x1199 and Intel Vendor (0x8086)
 #define MMAP_PATH "/sys/devices/pci0000:00/0000:00:0c.0/resource0"
-#define UART_DEV_PATH "/dev/ttyMFD1"
+#define UART_DEV_PATH ((vanilla_kernel == 0)?"/dev/ttyMFD1":"/dev/ttyS1")
 
 typedef struct {
     int sysfs;
@@ -70,6 +71,7 @@ static mraa_gpio_context agpioOutputen[sizeof(outputen) / sizeof(outputen[0])];
 static unsigned int pullup_map[] = { 216, 217, 218, 219, 220, 221, 222, 223, 224, 225,
                                      226, 227, 228, 229, 208, 209, 210, 211, 212, 213 };
 static int miniboard = 0;
+static int vanilla_kernel = 0;
 
 // MMAP
 static uint8_t* mmap_reg = NULL;
@@ -115,6 +117,11 @@ mraa_intel_edison_pinmode_change(int sysfs, int mode)
         return MRAA_SUCCESS;
     }
 
+    if (vanilla_kernel != 0) {
+        syslog(LOG_NOTICE, "edison: Vanilla kernel does not support setting pinmux %d", sysfs);
+        return MRAA_SUCCESS;
+    }
+    
     char buffer[MAX_SIZE];
     int useDebugFS = 0;
 
@@ -656,27 +663,48 @@ mraa_intel_edison_uart_init_pre(int index)
     }
     if (miniboard == 0) {
         mraa_gpio_write(tristate, 0);
-        mraa_gpio_context io0_output = mraa_gpio_init_raw(248);
+        mraa_gpio_context io0_output = mraa_gpio_init_raw(248); /* RXD */
         mraa_gpio_context io0_pullup = mraa_gpio_init_raw(216);
-        mraa_gpio_context io1_output = mraa_gpio_init_raw(249);
+        mraa_gpio_context io1_output = mraa_gpio_init_raw(249); /* TXD */
         mraa_gpio_context io1_pullup = mraa_gpio_init_raw(217);
+        mraa_gpio_context io2_output = mraa_gpio_init_raw(250); /* CTS */
+        mraa_gpio_context io2_pullup = mraa_gpio_init_raw(218);
+        mraa_gpio_context io4_output = mraa_gpio_init_raw(252); /* RTS */
+        mraa_gpio_context io4_pullup = mraa_gpio_init_raw(220);
+
         mraa_gpio_dir(io0_output, MRAA_GPIO_OUT);
         mraa_gpio_dir(io0_pullup, MRAA_GPIO_OUT);
         mraa_gpio_dir(io1_output, MRAA_GPIO_OUT);
         mraa_gpio_dir(io1_pullup, MRAA_GPIO_IN);
+        mraa_gpio_dir(io2_output, MRAA_GPIO_OUT);
+        mraa_gpio_dir(io2_pullup, MRAA_GPIO_OUT);
+        mraa_gpio_dir(io4_output, MRAA_GPIO_OUT);
+        mraa_gpio_dir(io4_pullup, MRAA_GPIO_IN);
+
 
         mraa_gpio_write(io0_output, 0);
         mraa_gpio_write(io0_pullup, 0);
         mraa_gpio_write(io1_output, 1);
+        mraa_gpio_write(io2_output, 0);
+        mraa_gpio_write(io2_pullup, 0);
+        mraa_gpio_write(io4_output, 1);
+
 
         mraa_gpio_close(io0_output);
         mraa_gpio_close(io0_pullup);
         mraa_gpio_close(io1_output);
         mraa_gpio_close(io1_pullup);
+        mraa_gpio_close(io2_output);
+        mraa_gpio_close(io2_pullup);
+        mraa_gpio_close(io4_output);
+        mraa_gpio_close(io4_pullup);
+
     }
     mraa_result_t ret;
     ret = mraa_intel_edison_pinmode_change(130, 1); // IO0 RX
     ret = mraa_intel_edison_pinmode_change(131, 1); // IO1 TX
+    ret = mraa_intel_edison_pinmode_change(128, 1); // IO2 CTS
+    ret = mraa_intel_edison_pinmode_change(129, 1); // IO4 RTS
     return ret;
 }
 
@@ -1281,6 +1309,9 @@ mraa_board_t*
 mraa_intel_edison_fab_c()
 {
     mraa_gpio_dir_t tristate_dir;
+    struct utsname name;
+    int major, minor, release;
+    int ret;
     mraa_board_t* b = (mraa_board_t*) calloc(1, sizeof(mraa_board_t));
     if (b == NULL) {
         return NULL;
@@ -1288,6 +1319,25 @@ mraa_intel_edison_fab_c()
 
     b->platform_name = PLATFORM_NAME;
 
+    if (uname(&name) != 0) {
+        goto error;
+    }
+   
+    ret = sscanf(name.release, "%d.%d.%d", &major, &minor, &release);
+    if (ret == 2) {
+        ret++;
+        release = 0;
+    }
+    if (ret < 2) {
+        goto error;
+    }
+        
+    if (major >= 4) {
+        vanilla_kernel = 1;
+        syslog(LOG_NOTICE,
+               "edison: Linux version 4 or higher detected, assuming Vanilla kernel"); 
+    };
+    
     if (is_arduino_board() == 0) {
         syslog(LOG_NOTICE,
                "edison: Arduino board not detected, assuming Intel Edison Miniboard");


### PR DESCRIPTION
mraa: patch for vanilla kernel >= 4.x.x

Vanilla kernel have the serial port on ttyS1 instead of ttyMFD1 and don't support changing pinmux at run time. It is envisioned that pinmux should be set by acpi tables that will be passed from u-boot to the kernel. 
For now serial port pinmux is pre-configured to allow ttyS1 with flow control. I.e. J17-14, J18-12, J18-13 and J19-8 on mini-breakout board and IO0, IO1, IO2 and IO4 on the arduino board are reserved for serial communication.

This patch detects the kernel version and sets the default serial port to ttyS1 for kernels >= 4.x.x and disables pinmux changes. A warning is set to syslog when this attempted.

Signed-off-by: Ferry Toth <ftoth@exalondelft.nl>

My branch eds is from master tag v1.7.0