### PR TITLE
Minor fixes for beaglebone I2C initialization

### DIFF
--- a/src/arm/beaglebone.c
+++ b/src/arm/beaglebone.c
@@ -272,9 +272,9 @@ mraa_beaglebone_i2c_init_pre(unsigned int bus)
     if (mraa_file_exist(devpath)) {
         // Bus 1 doesn't seem to be configurable
         if (bus == 0) {
-            if (set_pin_mode(plat->i2c_bus[0].scl, "i2c") == MRAA_SUCCESS &&
-                set_pin_mode(plat->i2c_bus[0].sda, "i2c") == MRAA_SUCCESS) {
-                return MRAA_SUCCESS;
+            if (set_pin_mode(plat->i2c_bus[0].scl, "i2c") != MRAA_SUCCESS ||
+                set_pin_mode(plat->i2c_bus[0].sda, "i2c") != MRAA_SUCCESS) {
+                return MRAA_ERROR_UNSPECIFIED;
             }
         }
 

--- a/src/arm/beaglebone.c
+++ b/src/arm/beaglebone.c
@@ -264,7 +264,7 @@ mraa_beaglebone_i2c_init_pre(unsigned int bus)
     mraa_result_t ret = MRAA_ERROR_NO_RESOURCES;
     char devpath[MAX_SIZE];
 
-    sprintf(devpath, "/dev/i2c-%u", bus);
+    snprintf(devpath, MAX_SIZE, "/dev/i2c-%u", bus);
 
     if (!mraa_file_exist(devpath)) {
         ret = MRAA_ERROR_INVALID_HANDLE;

--- a/src/arm/beaglebone.c
+++ b/src/arm/beaglebone.c
@@ -275,7 +275,7 @@ mraa_beaglebone_i2c_init_pre(unsigned int bus)
             }
         }
 
-        return MRAA_SUCCESS;
+        ret = MRAA_SUCCESS;
     } else {
         syslog(LOG_ERR, "i2c: Device %s not initialized", devpath);
         ret = MRAA_ERROR_INVALID_HANDLE;

--- a/src/arm/beaglebone.c
+++ b/src/arm/beaglebone.c
@@ -266,9 +266,6 @@ mraa_beaglebone_i2c_init_pre(unsigned int bus)
 
     snprintf(devpath, MAX_SIZE, "/dev/i2c-%u", bus);
 
-    if (!mraa_file_exist(devpath)) {
-        ret = MRAA_ERROR_INVALID_HANDLE;
-    }
     if (mraa_file_exist(devpath)) {
         // Bus 1 doesn't seem to be configurable
         if (bus == 0) {
@@ -281,6 +278,7 @@ mraa_beaglebone_i2c_init_pre(unsigned int bus)
         return MRAA_SUCCESS;
     } else {
         syslog(LOG_ERR, "i2c: Device %s not initialized", devpath);
+        ret = MRAA_ERROR_INVALID_HANDLE;
     }
     return ret;
 }


### PR DESCRIPTION
The i2c_init_pre function for beaglebone seems to be a ... bit messy.
This is an attempt to fix it.
The only functionality change is that on failure to mux bus pins, the function now returns error.
Before these patches the return value is always success, but the way the code was written, that appears to be non-intentional.