### PR TITLE
examples: Remove heap allocation from C++ examples

### DIFF
--- a/examples/c++/AioA0.cpp
+++ b/examples/c++/AioA0.cpp
@@ -44,20 +44,17 @@ main()
 {
     uint16_t adc_value;
     float adc_value_float;
-    mraa::Aio* a0;
-
-    a0 = new mraa::Aio(0);
+    mraa::Aio a0(0);
 
     signal(SIGINT, sig_handler);
 
     while (running == 0) {
-        adc_value = a0->read();
-        adc_value_float = a0->readFloat();
+        adc_value = a0.read();
+        adc_value_float = a0.readFloat();
         fprintf(stdout, "ADC A0 read %X - %d\n", adc_value, adc_value);
         fprintf(stdout, "ADC A0 read float - %.5f (Ctrl+C to exit)\n", adc_value_float);
     }
 
-    delete a0;
     return MRAA_SUCCESS;
 }
 //! [Interesting]

--- a/examples/c++/Blink-IO.cpp
+++ b/examples/c++/Blink-IO.cpp
@@ -55,21 +55,19 @@ main(int argc, char** argv)
     signal(SIGINT, sig_handler);
 
     //! [Interesting]
-    mraa::Gpio* gpio = new mraa::Gpio(iopin);
-    mraa::Result response = gpio->dir(mraa::DIR_OUT);
+    mraa::Gpio gpio(iopin);
+    mraa::Result response = gpio.dir(mraa::DIR_OUT);
     if (response != mraa::SUCCESS) {
         mraa::printError(response);
-        delete gpio;
         return 1;
     }
 
     while (running == 0) {
-        response = gpio->write(1);
+        response = gpio.write(1);
         sleep(1);
-        response = gpio->write(0);
+        response = gpio.write(0);
         sleep(1);
     }
-    delete gpio;
     return response;
     //! [Interesting]
 }

--- a/examples/c++/I2c-compass.cpp
+++ b/examples/c++/I2c-compass.cpp
@@ -99,28 +99,27 @@ main()
     uint8_t rx_tx_buf[MAX_BUFFER_LENGTH];
 
     //! [Interesting]
-    mraa::I2c* i2c;
-    i2c = new mraa::I2c(0);
+    mraa::I2c i2c(0);
 
-    i2c->address(HMC5883L_I2C_ADDR);
+    i2c.address(HMC5883L_I2C_ADDR);
     rx_tx_buf[0] = HMC5883L_CONF_REG_B;
     rx_tx_buf[1] = GA_1_3_REG;
-    i2c->write(rx_tx_buf, 2);
+    i2c.write(rx_tx_buf, 2);
     //! [Interesting]
 
-    i2c->address(HMC5883L_I2C_ADDR);
+    i2c.address(HMC5883L_I2C_ADDR);
     rx_tx_buf[0] = HMC5883L_MODE_REG;
     rx_tx_buf[1] = HMC5883L_CONT_MODE;
-    i2c->write(rx_tx_buf, 2);
+    i2c.write(rx_tx_buf, 2);
 
     signal(SIGINT, sig_handler);
 
     while (running == 0) {
-        i2c->address(HMC5883L_I2C_ADDR);
-        i2c->writeByte(HMC5883L_DATA_REG);
+        i2c.address(HMC5883L_I2C_ADDR);
+        i2c.writeByte(HMC5883L_DATA_REG);
 
-        i2c->address(HMC5883L_I2C_ADDR);
-        i2c->read(rx_tx_buf, DATA_REG_SIZE);
+        i2c.address(HMC5883L_I2C_ADDR);
+        i2c.read(rx_tx_buf, DATA_REG_SIZE);
 
         x = (rx_tx_buf[HMC5883L_X_MSB_REG] << 8) | rx_tx_buf[HMC5883L_X_LSB_REG];
         z = (rx_tx_buf[HMC5883L_Z_MSB_REG] << 8) | rx_tx_buf[HMC5883L_Z_LSB_REG];
@@ -138,7 +137,6 @@ main()
         printf("Heading : %f\n", direction * 180 / M_PI);
         sleep(1);
     }
-    delete i2c;
 
     return MRAA_SUCCESS;
 }

--- a/examples/c++/Isr-pin6.cpp
+++ b/examples/c++/Isr-pin6.cpp
@@ -39,11 +39,11 @@ interrupt(void* args)
 int
 main()
 {
-    mraa::Gpio* x = new mraa::Gpio(6);
+    mraa::Gpio x(6);
 
-    x->dir(mraa::DIR_IN);
+    x.dir(mraa::DIR_IN);
 
-    x->isr(mraa::EDGE_BOTH, &interrupt, NULL);
+    x.isr(mraa::EDGE_BOTH, &interrupt, NULL);
 
     int i = 100;
     for (; i > 0; --i) {
@@ -55,6 +55,5 @@ main()
         sleep(1);
     }
 
-    delete x;
     return MRAA_SUCCESS;
 }

--- a/examples/c++/Pwm3-cycle.cpp
+++ b/examples/c++/Pwm3-cycle.cpp
@@ -43,22 +43,19 @@ main()
 {
     signal(SIGINT, sig_handler);
     //! [Interesting]
-    mraa::Pwm* pwm;
-
-    pwm = new mraa::Pwm(3);
+    mraa::Pwm pwm(3);
     fprintf(stdout, "Cycling PWM on IO3 (pwm3) \n");
-    pwm->enable(true);
+    pwm.enable(true);
 
     float value = 0.0f;
     while (running == 0) {
         value = value + 0.01f;
-        pwm->write(value);
+        pwm.write(value);
         usleep(50000);
         if (value >= 1.0f) {
             value = 0.0f;
         }
     }
-    delete pwm;
     //! [Interesting]
 
     return MRAA_SUCCESS;

--- a/examples/c++/Spi-pot.cpp
+++ b/examples/c++/Spi-pot.cpp
@@ -45,9 +45,7 @@ main()
     signal(SIGINT, sig_handler);
 
     //! [Interesting]
-    mraa::Spi* spi;
-
-    spi = new mraa::Spi(0);
+    mraa::Spi spi(0);
 
     uint8_t data[] = { 0x00, 100 };
     uint8_t rxBuf[2];
@@ -56,7 +54,7 @@ main()
         int i;
         for (i = 90; i < 130; i++) {
             data[1] = i;
-            recv = spi->write(data, 2);
+            recv = spi.write(data, 2);
             printf("Writing -%i", i);
             if (recv) {
                 printf("RECIVED-%i-%i\n", recv[0], recv[1]);
@@ -66,14 +64,13 @@ main()
         }
         for (i = 130; i > 90; i--) {
             data[1] = i;
-            if (spi->transfer(data, rxBuf, 2) == mraa::SUCCESS) {
+            if (spi.transfer(data, rxBuf, 2) == mraa::SUCCESS) {
                 printf("Writing -%i", i);
                 printf("RECIVED-%i-%i\n", rxBuf[0], rxBuf[1]);
             }
             usleep(100000);
         }
     }
-    delete spi;
     //! [Interesting]
 
     return mraa::SUCCESS;

--- a/examples/c++/UartOW.cpp
+++ b/examples/c++/UartOW.cpp
@@ -30,16 +30,15 @@
 int
 main(int argc, char** argv)
 {
-    mraa::UartOW* uart = new mraa::UartOW(0);
+    mraa::UartOW uart(0);
 
     // Reset the ow bus and see if anything is present
     mraa::Result rv;
 
-    if ((rv = uart->reset()) == mraa::SUCCESS) {
+    if ((rv = uart.reset()) == mraa::SUCCESS) {
         std::cout << "Reset succeeded, device(s) detected!" << std::endl;
     } else {
         std::cout << "Reset failed, returned " << int(rv) << ". No devices on bus?" << std::endl;
-        delete uart;
         return 1;
     }
 
@@ -48,11 +47,10 @@ main(int argc, char** argv)
 
     uint8_t count = 0;
     // start the search from scratch
-    std::string id = uart->search(true);
+    std::string id = uart.search(true);
 
     if (id.empty()) {
         std::cout << "No devices detected." << std::endl;
-        delete uart;
         return 1;
     }
 
@@ -70,12 +68,10 @@ main(int argc, char** argv)
         count++;
 
         // continue the search with start argument set to false
-        id = uart->search(false);
+        id = uart.search(false);
     }
 
     std::cout << "Exiting..." << std::endl;
-
-    delete uart;
 
     return 0;
 }


### PR DESCRIPTION
Small cleanup of MRAA C++ examples.  Switched from heap allocation to
stack allocation when possible.  This simplifies the samples since it
removes the need for explicit memory management.

Signed-off-by: Noel Eck <noel.eck@intel.com>