### PR TITLE
iio: Allow mraa_iio_trigger_buffer to handle void* args

### DIFF
--- a/api/mraa/iio.h
+++ b/api/mraa/iio.h
@@ -102,7 +102,7 @@ mraa_iio_context mraa_iio_init(int device);
  * @param args Arguments
  * @return Result of operation
  */
-mraa_result_t mraa_iio_trigger_buffer(mraa_iio_context dev, void (*fptr)(char* data), void* args);
+mraa_result_t mraa_iio_trigger_buffer(mraa_iio_context dev, void (*fptr)(char*, void*), void* args);
 
 /**
  * Get device name

--- a/examples/iio_driver.c
+++ b/examples/iio_driver.c
@@ -46,16 +46,15 @@ printword(uint16_t input, mraa_iio_channel* chan)
     printf("  value = %05f\n", (float) res);
 }
 
-mraa_iio_context iio_device0;
-mraa_iio_context iio_device6;
-
 void
-interrupt(char* data)
+interrupt(char* data, void* args)
 {
-    mraa_iio_channel* channels = mraa_iio_get_channels(iio_device0);
+    mraa_iio_context thisdevice = (mraa_iio_context)args;
+
+    mraa_iio_channel* channels = mraa_iio_get_channels(thisdevice);
     int i = 0;
 
-    for (; i < mraa_iio_get_channel_count(iio_device0); i++) {
+    for (; i < mraa_iio_get_channel_count(thisdevice); i++) {
         if (channels[i].enabled) {
             printf("channel %d - bytes %d\n", channels[i].index, channels[i].bytes);
             switch (channels[i].bytes) {
@@ -87,7 +86,8 @@ int
 main()
 {
     //! [Interesting]
-    iio_device0 = mraa_iio_init(0);
+    mraa_iio_context iio_device0 = mraa_iio_init(0);
+
     if (iio_device0 == NULL) {
         return EXIT_FAILURE;
     }
@@ -116,7 +116,7 @@ main()
         fprintf(stdout, "IIO read %d\n", iio_int);
     }
 
-    if (mraa_iio_trigger_buffer(iio_device0, interrupt, NULL) == MRAA_SUCCESS) {
+    if (mraa_iio_trigger_buffer(iio_device0, interrupt, (void*)iio_device0) == MRAA_SUCCESS) {
         sleep(100);
         return EXIT_SUCCESS;
     }

--- a/include/mraa_internal_types.h
+++ b/include/mraa_internal_types.h
@@ -229,7 +229,7 @@ struct _iio {
     char* name; /**< IIO device name */
     int fp; /**< IIO device in /dev */
     int fp_event;  /**<  event file descriptor for IIO device */
-    void (* isr)(char* data); /**< the interrupt service request */
+    void (* isr)(char* data, void* args); /**< the interrupt service request */
     void *isr_args; /**< args return when interrupt service request triggered */
     void (* isr_event)(struct iio_event_data* data, void* args); /**< the event interrupt service request */
     int chan_num;

--- a/src/iio/iio.c
+++ b/src/iio/iio.c
@@ -332,7 +332,7 @@ mraa_iio_trigger_handler(void* arg)
 #endif
             // only can process if readsize >= enabled channel's datasize
             for (i = 0; i < (read_size / dev->datasize); i++) {
-                dev->isr((void*)&data);
+                dev->isr((char*)&data, (void*)dev->isr_args);
             }
 #ifdef HAVE_PTHREAD_CANCEL
             pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
@@ -348,7 +348,7 @@ mraa_iio_trigger_handler(void* arg)
 }
 
 mraa_result_t
-mraa_iio_trigger_buffer(mraa_iio_context dev, void (*fptr)(char* data), void* args)
+mraa_iio_trigger_buffer(mraa_iio_context dev, void (*fptr)(char*, void*), void* args)
 {
     char bu[MAX_SIZE];
     if (dev->thread_id != 0) {
@@ -362,6 +362,7 @@ mraa_iio_trigger_buffer(mraa_iio_context dev, void (*fptr)(char* data), void* ar
     }
 
     dev->isr = fptr;
+    dev->isr_args = args;
     pthread_create(&dev->thread_id, NULL, mraa_iio_trigger_handler, (void*) dev);
 
     return MRAA_SUCCESS;


### PR DESCRIPTION
Previously, mraa_iio_trigger_buffer took a void* args but did not use
this.  Included implementation to allow user to pass a void* to this
method and have the corresponding pointer returned in the interrupt
handler provided.

Signed-off-by: Noel Eck <noel.eck@intel.com>