### PR TITLE
Adding PWM support to Pi

### DIFF
--- a/src/arm/raspberry_pi.c
+++ b/src/arm/raspberry_pi.c
@@ -159,7 +159,7 @@ mmap_regs()
 {
     // Already mapped!
     if (clk_reg || gpio_reg || pwm_reg) {
-        return;
+        return 0;
     }
 
     clk_reg = mmap_reg_addr(peripheral_base + CLOCK_OFFSET);


### PR DESCRIPTION
So, the Pi doesn't have userspace level PWM support, but you can mmap the raw registers and configure it that way, which is what this patch is doing. Tested with Raspberry Pi 3 B. I am able to set the duty cycle, change the frequency, and set the pulse width. Signals verified with logic analyzer.

Let me know if there's anything that you think needs cleaning up.

Note that the only accessible pwm is on GPIO18, which is also used by the audio subsystem.