### PR TITLE
Topic/fix adc up1

### DIFF
--- a/examples/analogin_a0.c
+++ b/examples/analogin_a0.c
@@ -60,6 +60,7 @@ main()
         adc_value_float = mraa_aio_read_float(adc_a0);
         fprintf(stdout, "ADC A0 read %X - %d\n", adc_value, adc_value);
         fprintf(stdout, "ADC A0 read float - %.5f (Ctrl+C to exit)\n", adc_value_float);
+        sleep(1);
     }
 
     r = mraa_aio_close(adc_a0);

--- a/src/x86/up.c
+++ b/src/x86/up.c
@@ -241,6 +241,8 @@ mraa_up_board()
     b->aio_count = 1;
     b->adc_raw = 8;
     b->adc_supported = 8;
+    b->aio_non_seq = 1;
+    mraa_up_get_pin_index(b, "ADC0", (int*) &(b->aio_dev[0].pin));
 
     const char* pinctrl_path = "/sys/bus/platform/drivers/up-pinctrl";
     int have_pinctrl = access(pinctrl_path, F_OK) != -1;


### PR DESCRIPTION
Various fixes for aio
1) problem with max_analog_value:
if the adc has a resolution of 8 bit for example the maximum value is 255.
if the default resolution set for the aio module is 10 bit we get that a value of 255 get shifted by 2 bit and gives 1020 (not 1023)
the max analog value was before set to 2^10 -1 = 1023
so the maximum value of the adc would not give a floating value of 1 (1020 < 1023)
2) some values were set for every read but could be set in the init function
3) there's something that I don;t understand about the numbering of the pin in the aio modules.
the UP was getting a wrong ANALOG pin value of 28.
Fixed setting aio_non_seq in the up adc properties in the board definition variable

Regards
Nicola Lunghi