### PR TITLE
mraa.c: make mraa_gpio_lookup() return proper pin index

### DIFF
--- a/src/mraa.c
+++ b/src/mraa.c
@@ -883,7 +883,7 @@ mraa_gpio_lookup(const char* pin_name)
     for (i = 0; i < plat->gpio_count; i++) {
          if (plat->pins[i].name != NULL &&
              strncmp(pin_name, plat->pins[i].name, strlen(plat->pins[i].name) + 1) == 0) {
-             return plat->pins[i].gpio.pinmap;
+             return i;
          }
     }
     return -1;


### PR DESCRIPTION
Here goes the fix for #817, per our discussion there. I've checked and `mraa_gpio_lookup()` is actually not used anywhere in the mraa or upm code (including mraa's `peripheralman.c`).

This, in addition to the fact that Peripheral Manager-specific init code assigns mraa indexes to `pinmap` field, means to me that this change is going to be transparent to it and no changes needed there, as the values are effectively the same.

I'd leave it to those more familiar with ways Peripheral Manager-specific code uses this function, to decide if that's really the case, but to me it looks as if there's even no need to postpone merging this until the 2.0.