### PR TITLE
include endian.h for be16toh and le16toh declarations

### DIFF
--- a/examples/c/i2c_mpu6050.c
+++ b/examples/c/i2c_mpu6050.c
@@ -27,6 +27,7 @@
  */
 
 /* standard headers */
+#include <endian.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/c/iio.c
+++ b/examples/c/iio.c
@@ -28,6 +28,7 @@
 /* standard headers */
 #include <stdlib.h>
 #include <unistd.h>
+#include <endian.h>
 
 /* mraa header */
 #include "mraa/iio.h"


### PR DESCRIPTION
this gets exposed on musl, on glibc endian.h gets pulled
in indirectly

Signed-off-by: Khem Raj <raj.khem@gmail.com>