### PR TITLE
static code analysis: correct SonarCloud URL

### DIFF
--- a/docs/static_code_analysis.md
+++ b/docs/static_code_analysis.md
@@ -67,7 +67,7 @@ $> sonar-scanner \
     -Dsonar.sources=/PATH/TO/YOUR/MRAA/REPO/CLONE \
     -Dsonar.inclusions='api/**/*,CMakeLists.txt,examples/**/*,imraa/**/*,include/**/*,src/*,src/**/*,tests/**/*' \
     -Dsonar.cfamily.build-wrapper-output=/PATH/TO/YOUR/MRAA/REPO/CLONE/YOUR_BUILD_DIR/bw-output \
-    -Dsonar.host.url=https://sonarqube.com \
+    -Dsonar.host.url=https://sonarcloud.io \
     -Dsonar.organization=mraa-github \
     -Dsonar.login=YOUR_SONAR_LOGIN_TOKEN_HERE
 ```

--- a/scripts/sonar-scan.sh
+++ b/scripts/sonar-scan.sh
@@ -54,7 +54,7 @@ sonar_cmd_base="build-wrapper-linux-x86-64 --out-dir ${bw_output_path} make clea
         -Dsonar.java.binaries='src' \
         -Dsonar.coverage.exclusions='**/*' \
         -Dsonar.cfamily.build-wrapper-output=${bw_output_path} \
-        -Dsonar.host.url=https://sonarqube.com \
+        -Dsonar.host.url=https://sonarcloud.io \
         -Dsonar.organization=${SONAR_ORG} \
         -Dsonar.login=${SONAR_TOKEN} \
 "


### PR DESCRIPTION
According to SonarCloud's email notification,
they're dropping sonarqube.com in favor of sonarcloud.io.