### PR TITLE
Fix bugs related to flag usage in chardev gpio

### DIFF
--- a/src/gpio/gpio_chardev.c
+++ b/src/gpio/gpio_chardev.c
@@ -375,7 +375,7 @@ mraa_get_line_values(int line_handle, unsigned int num_lines, unsigned char outp
 mraa_boolean_t
 mraa_is_gpio_line_kernel_owned(mraa_gpiod_line_info *linfo)
 {
-    return (linfo->flags & GPIOLINE_FLAG_IS_OUT);
+    return (linfo->flags & GPIOLINE_FLAG_KERNEL);
 }
 
 mraa_boolean_t

--- a/src/gpio/gpio_chardev.c
+++ b/src/gpio/gpio_chardev.c
@@ -399,7 +399,7 @@ mraa_is_gpio_line_open_drain(mraa_gpiod_line_info *linfo)
 mraa_boolean_t
 mraa_is_gpio_line_open_source(mraa_gpiod_line_info *linfo)
 {
-    return (linfo->flags & GPIOHANDLE_REQUEST_OPEN_SOURCE);
+    return (linfo->flags & GPIOLINE_FLAG_OPEN_SOURCE);
 }
 
 int


### PR DESCRIPTION
This PR fixes couple of bugs in the Chardev gpio interface regarding the usage of gpio line flags. These issues are reported by the GPIO subsystem maintainer Linus Walleij.