### PR TITLE
cmake: force c99 to be set in the compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,14 @@ project (mraa C CXX)
 
 FIND_PACKAGE (Threads REQUIRED)
 
+if (CMAKE_VERSION VERSION_LESS "3.1")
+  if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    set (CMAKE_C_FLAGS "-std=gnu99 ${CMAKE_C_FLAGS}")
+  endif ()
+else ()
+  set (CMAKE_C_STANDARD 99)
+endif ()
+
 ###############################################################################
 # Detect supported warning flags
 # Modified from work By Dan Liew (fpbench - MIT)


### PR DESCRIPTION
Signed-off-by: Brendan Le Foll <brendan.le.foll@intel.com>