### PR TITLE
gpio: chardev: fix leaking of gpiochip file descriptors

### DIFF
--- a/src/gpio/gpio_chardev.c
+++ b/src/gpio/gpio_chardev.c
@@ -295,6 +295,7 @@ mraa_get_line_info_by_chip_number(unsigned chip_number, unsigned line_number)
 
     linfo = mraa_get_line_info_from_descriptor(cinfo->chip_fd, line_number);
 
+    close(cinfo->chip_fd);
     free(cinfo);
 
     return linfo;
@@ -314,6 +315,7 @@ mraa_get_line_info_by_chip_name(const char* chip_name, unsigned line_number)
 
     linfo = mraa_get_line_info_from_descriptor(cinfo->chip_fd, line_number);
 
+    close(cinfo->chip_fd);
     free(cinfo);
 
     return linfo;
@@ -333,6 +335,7 @@ mraa_get_line_info_by_chip_label(const char* chip_label, unsigned line_number)
 
     linfo = mraa_get_line_info_from_descriptor(cinfo->chip_fd, line_number);
 
+    close(cinfo->chip_fd);
     free(cinfo);
 
     return linfo;


### PR DESCRIPTION
The following APIs are only used for getting the line information from
kernel by opening the gpiochip independently and they fails to close
the file descriptor when done:

1. mraa_get_line_info_by_chip_number()
2. mraa_get_line_info_by_chip_name()
3. mraa_get_line_info_by_chip_label()

This will create issue if these API consumers like mraa_gpio_read_dir(),
mraa_gpio_mode(), mraa_gpio_chardev_dir() gets called in a loop. The
system will run out of file descriptor after some time.

Fix this issue by closing the opened file descriptors before freeing
the cinfo struct.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>