### PR TITLE
96boards: Add Hikey960 board support

### DIFF
--- a/docs/96boards.md
+++ b/docs/96boards.md
@@ -11,6 +11,7 @@ Board Support
 - [DragonBoard 410c](http://www.96boards.org/product/dragonboard410c/)
 - [DragonBoard 820c](http://www.96boards.org/product/dragonboard820c/)
 - [HiKey](http://www.96boards.org/product/hikey/)
+- [HiKey960](http://www.96boards.org/product/hikey960/)
 - [Bubblegum-96](http://www.96boards.org/product/bubblegum-96/)
 
 Interface notes

--- a/src/arm/96boards.c
+++ b/src/arm/96boards.c
@@ -39,6 +39,7 @@
 #define PLATFORM_NAME_DB410C "DB410C"
 #define PLATFORM_NAME_DB820C "DB820C"
 #define PLATFORM_NAME_HIKEY "HIKEY"
+#define PLATFORM_NAME_HIKEY960 "HIKEY960"
 #define PLATFORM_NAME_BBGUM "BBGUM"
 #define MAX_SIZE 64
 #define MMAP_PATH "/dev/mem"
@@ -76,6 +77,14 @@ int hikey_chardev_map[MRAA_96BOARDS_LS_GPIO_COUNT][2] = {
 };
 
 const char* hikey_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyAMA2", "/dev/ttyAMA3" };
+
+// HIKEY960
+int hikey960_chardev_map[MRAA_96BOARDS_LS_GPIO_COUNT][2] = {
+    { 26, 0 }, { 26, 1 }, { 26, 2 },  { 26, 3 }, { 26, 4 },  { 22, 6 },
+    { 2, 7 }, { 5, 0 }, { 6, 4 }, { 2, 3 }, { 9, 3 }, { 2, 5 },
+};
+
+const char* hikey960_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyAMA3", "/dev/ttyAMA6" };
 
 int bbgum_ls_gpio_pins[MRAA_96BOARDS_LS_GPIO_COUNT] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 155, 154 };
 
@@ -248,6 +257,12 @@ mraa_96boards()
             chardev_map = &hikey_chardev_map;
             b->uart_dev[0].device_path = (char*) hikey_serialdev[0];
             b->uart_dev[1].device_path = (char*) hikey_serialdev[1];
+            b->chardev_capable = 1;
+        } else if (mraa_file_contains(DT_BASE "/model", "HiKey960")) {
+            b->platform_name = PLATFORM_NAME_HIKEY960;
+            chardev_map = &hikey960_chardev_map;
+            b->uart_dev[0].device_path = (char*) hikey960_serialdev[0];
+            b->uart_dev[1].device_path = (char*) hikey960_serialdev[1];
             b->chardev_capable = 1;
         } else if (mraa_file_contains(DT_BASE "/model", "s900")) {
             b->platform_name = PLATFORM_NAME_BBGUM;

--- a/src/arm/96boards.c
+++ b/src/arm/96boards.c
@@ -111,12 +111,11 @@ mraa_96boards_pininfo(mraa_board_t* board, int index, int sysfs_pin, int is_gpio
         va_arg(arg_ptr, int);
         pininfo->gpio.gpio_chip = va_arg(arg_ptr, int);
         pininfo->gpio.gpio_line = va_arg(arg_ptr, int);
+        pininfo->capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
+    } else {
+        pininfo->capabilities = (mraa_pincapabilities_t){ 0, 0, 0, 0, 0, 0, 0, 0 };
     }
     va_end(arg_ptr);
-    if (sysfs_pin >= 0)
-        pininfo->capabilities = (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 };
-    else
-        pininfo->capabilities = (mraa_pincapabilities_t){ 0, 0, 0, 0, 0, 0, 0, 0 };
     pininfo->gpio.pinmap = sysfs_pin;
     pininfo->gpio.mux_total = 0;
 }

--- a/src/arm/arm.c
+++ b/src/arm/arm.c
@@ -92,6 +92,8 @@ mraa_arm_platform()
         else if (mraa_file_contains("/proc/device-tree/model",
                                     "HiKey Development Board"))
             platform_type = MRAA_96BOARDS;
+        else if (mraa_file_contains("/proc/device-tree/model", "HiKey960"))
+            platform_type = MRAA_96BOARDS;
         else if (mraa_file_contains("/proc/device-tree/model", "s900"))
             platform_type = MRAA_96BOARDS;
         else if (mraa_file_contains("/proc/device-tree/compatible", "raspberrypi,"))


### PR DESCRIPTION
Add 96Boards Hikey960 board support. Hikey960 is based on Huawei Kirin 960 octa-core ARM® big.LITTLE™ processor with four ARM Cortex®-A73 and four Cortex-A53 cores with 3GB of LPDDR4 SDRAM memory, 32GB of UFS 2.0 flash storage, and the latest generation Mali™ G71 MP8 GPU.

More information can be found in 96Boards product page: https://www.96boards.org/product/hikey960/

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>