### PR TITLE
96Boards: Add Ultra96 Board support

### DIFF
--- a/docs/96boards.md
+++ b/docs/96boards.md
@@ -8,11 +8,11 @@ Standardized expansion buses for peripheral I/O have led to a wide range of comp
 Board Support
 -------------
 
+- [Bubblegum-96](http://www.96boards.org/product/bubblegum-96/)
 - [DragonBoard 410c](http://www.96boards.org/product/dragonboard410c/)
 - [DragonBoard 820c](http://www.96boards.org/product/dragonboard820c/)
 - [HiKey](http://www.96boards.org/product/hikey/)
 - [HiKey960](http://www.96boards.org/product/hikey960/)
-- [Bubblegum-96](http://www.96boards.org/product/bubblegum-96/)
 - [Rock960](http://www.96boards.org/product/rock960/)
 
 Interface notes

--- a/docs/96boards.md
+++ b/docs/96boards.md
@@ -14,6 +14,7 @@ Board Support
 - [HiKey](http://www.96boards.org/product/hikey/)
 - [HiKey960](http://www.96boards.org/product/hikey960/)
 - [Rock960](http://www.96boards.org/product/rock960/)
+- [Ultra96](https://www.96boards.org/product/ultra96/)
 
 Interface notes
 ---------------

--- a/src/arm/96boards.c
+++ b/src/arm/96boards.c
@@ -36,16 +36,22 @@
 
 #define DT_BASE "/proc/device-tree"
 
+#define PLATFORM_NAME_BBGUM "BBGUM"
 #define PLATFORM_NAME_DB410C "DB410C"
 #define PLATFORM_NAME_DB820C "DB820C"
 #define PLATFORM_NAME_HIKEY "HIKEY"
 #define PLATFORM_NAME_HIKEY960 "HIKEY960"
-#define PLATFORM_NAME_BBGUM "BBGUM"
 #define PLATFORM_NAME_ROCK960 "ROCK960"
 #define MAX_SIZE 64
 #define MMAP_PATH "/dev/mem"
 #define DB410C_MMAP_REG 0x01000000
 
+// Bubblegum-96
+int bbgum_ls_gpio_pins[MRAA_96BOARDS_LS_GPIO_COUNT] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 155, 154 };
+
+const char* bbgum_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyS3", "/dev/ttyS5" };
+
+// Dragonboard410c
 int db410c_ls_gpio_pins[MRAA_96BOARDS_LS_GPIO_COUNT] = {
     36, 12, 13, 69, 115, 4, 24, 25, 35, 34, 28, 33,
 };
@@ -57,17 +63,19 @@ int db410c_chardev_map[MRAA_96BOARDS_LS_GPIO_COUNT][2] = {
 
 const char* db410c_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyMSM0", "/dev/ttyMSM1" };
 
+// Dragonboard820c
 int db820c_ls_gpio_pins[MRAA_96BOARDS_LS_GPIO_COUNT] = {
     80, 29, 124, 24, 62, 507, 10, 8, 25, 26, 23, 133,
 };
 
 int db820c_chardev_map[MRAA_96BOARDS_LS_GPIO_COUNT][2] = {
     { 0, 80 }, { 0, 29 }, { 0, 125 }, { 0, 24 }, { 0, 62 }, { 1, 4 },
-    { 0, 10 }, { 0, 8 }, { 0, 25 }, { 0, 26 }, { 0, 23 },  { 0, 133 },
+    { 0, 10 }, { 0, 8 },  { 0, 25 },  { 0, 26 }, { 0, 23 }, { 0, 133 },
 };
 
 const char* db820c_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyMSM0", "/dev/ttyMSM1" };
 
+// HiKey
 int hikey_ls_gpio_pins[MRAA_96BOARDS_LS_GPIO_COUNT] = {
     488, 489, 490, 491, 492, 415, 463, 495, 426, 433, 427, 434,
 };
@@ -79,17 +87,13 @@ int hikey_chardev_map[MRAA_96BOARDS_LS_GPIO_COUNT][2] = {
 
 const char* hikey_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyAMA2", "/dev/ttyAMA3" };
 
-// HIKEY960
+// HiKey960
 int hikey960_chardev_map[MRAA_96BOARDS_LS_GPIO_COUNT][2] = {
-    { 26, 0 }, { 26, 1 }, { 26, 2 },  { 26, 3 }, { 26, 4 },  { 22, 6 },
-    { 2, 7 }, { 5, 0 }, { 6, 4 }, { 2, 3 }, { 9, 3 }, { 2, 5 },
+    { 26, 0 }, { 26, 1 }, { 26, 2 }, { 26, 3 }, { 26, 4 }, { 22, 6 },
+    { 2, 7 },  { 5, 0 },  { 6, 4 },  { 2, 3 },  { 9, 3 },  { 2, 5 },
 };
 
 const char* hikey960_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyAMA3", "/dev/ttyAMA6" };
-
-int bbgum_ls_gpio_pins[MRAA_96BOARDS_LS_GPIO_COUNT] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 155, 154 };
-
-const char* bbgum_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyS3", "/dev/ttyS5" };
 
 // Rock960
 int rock960_ls_gpio_pins[MRAA_96BOARDS_LS_GPIO_COUNT] = { 
@@ -243,7 +247,13 @@ mraa_96boards()
 
     if (mraa_file_exist(DT_BASE "/model")) {
         // We are on a modern kernel, great!!!!
-        if (mraa_file_contains(DT_BASE "/model", "Qualcomm Technologies, Inc. APQ 8016 SBC")) {
+        if (mraa_file_contains(DT_BASE "/model", "s900")) {
+            b->platform_name = PLATFORM_NAME_BBGUM;
+            ls_gpio_pins = bbgum_ls_gpio_pins;
+            b->uart_dev[0].device_path = (char*) bbgum_serialdev[0];
+            b->uart_dev[1].device_path = (char*) bbgum_serialdev[1];
+        } else if (mraa_file_contains(DT_BASE "/model",
+                                      "Qualcomm Technologies, Inc. APQ 8016 SBC")) {
             b->platform_name = PLATFORM_NAME_DB410C;
             ls_gpio_pins = db410c_ls_gpio_pins;
             chardev_map = &db410c_chardev_map;
@@ -256,7 +266,7 @@ mraa_96boards()
             ls_gpio_pins = db820c_ls_gpio_pins;
             chardev_map = &db820c_chardev_map;
             b->uart_dev[0].device_path = (char*) db820c_serialdev[0];
-            b->uart_dev[1].device_path = (char *)db820c_serialdev[1];
+            b->uart_dev[1].device_path = (char*) db820c_serialdev[1];
             b->chardev_capable = 1;
         } else if (mraa_file_contains(DT_BASE "/model", "HiKey Development Board")) {
             b->platform_name = PLATFORM_NAME_HIKEY;
@@ -276,11 +286,6 @@ mraa_96boards()
             ls_gpio_pins = rock960_ls_gpio_pins;
             b->uart_dev[0].device_path = (char*) rock960_serialdev[0];
             b->uart_dev[1].device_path = (char*) rock960_serialdev[1];
-        } else if (mraa_file_contains(DT_BASE "/model", "s900")) {
-            b->platform_name = PLATFORM_NAME_BBGUM;
-            ls_gpio_pins = bbgum_ls_gpio_pins;
-            b->uart_dev[0].device_path = (char*) bbgum_serialdev[0];
-            b->uart_dev[1].device_path = (char*) bbgum_serialdev[1];
         }
     }
 

--- a/src/arm/96boards.c
+++ b/src/arm/96boards.c
@@ -42,6 +42,8 @@
 #define PLATFORM_NAME_HIKEY "HIKEY"
 #define PLATFORM_NAME_HIKEY960 "HIKEY960"
 #define PLATFORM_NAME_ROCK960 "ROCK960"
+#define PLATFORM_NAME_ULTRA96 "ULTRA96"
+
 #define MAX_SIZE 64
 #define MMAP_PATH "/dev/mem"
 #define DB410C_MMAP_REG 0x01000000
@@ -101,6 +103,14 @@ int rock960_ls_gpio_pins[MRAA_96BOARDS_LS_GPIO_COUNT] = {
 };
 
 const char* rock960_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyS3", "/dev/ttyS4" };
+
+// Ultra96
+int ultra96_chardev_map[MRAA_96BOARDS_LS_GPIO_COUNT][2] = {
+    { 0, 36 }, { 0, 37 }, { 0, 39 }, { 0, 40 }, { 0, 44 }, { 0, 45 },
+    { 0, 78 }, { 0, 79 }, { 0, 80 }, { 0, 81 }, { 0, 82 }, { 0, 83 },
+};
+
+const char* ultra96_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyPS0", "/dev/ttyS0" };
 
 // MMAP
 static uint8_t* mmap_reg = NULL;
@@ -286,6 +296,12 @@ mraa_96boards()
             ls_gpio_pins = rock960_ls_gpio_pins;
             b->uart_dev[0].device_path = (char*) rock960_serialdev[0];
             b->uart_dev[1].device_path = (char*) rock960_serialdev[1];
+        } else if (mraa_file_contains(DT_BASE "/model", "ZynqMP ZCU100 RevC")) {
+            b->platform_name = PLATFORM_NAME_ULTRA96;
+            chardev_map = &ultra96_chardev_map;
+            b->uart_dev[0].device_path = (char*) ultra96_serialdev[0];
+            b->uart_dev[1].device_path = (char*) ultra96_serialdev[1];
+            b->chardev_capable = 1;
         }
     }
 
@@ -304,6 +320,11 @@ mraa_96boards()
         b->def_i2c_bus = 0;
         b->i2c_bus[0].bus_id = 6;
         b->i2c_bus[1].bus_id = 1;
+    } else if (strncmp(b->platform_name, PLATFORM_NAME_ULTRA96, MAX_SIZE) == 0) {
+        b->i2c_bus_count = MRAA_96BOARDS_LS_I2C_COUNT;
+        b->def_i2c_bus = 0;
+        b->i2c_bus[0].bus_id = 2;
+        b->i2c_bus[1].bus_id = 3;
     } else {
         b->i2c_bus_count = MRAA_96BOARDS_LS_I2C_COUNT;
         b->def_i2c_bus = 0;

--- a/src/arm/arm.c
+++ b/src/arm/arm.c
@@ -98,6 +98,8 @@ mraa_arm_platform()
             platform_type = MRAA_96BOARDS;
         else if (mraa_file_contains("/proc/device-tree/model", "ROCK960"))
             platform_type = MRAA_96BOARDS;
+        else if (mraa_file_contains("/proc/device-tree/model", "ZynqMP ZCU100 RevC"))
+            platform_type = MRAA_96BOARDS;
         else if (mraa_file_contains("/proc/device-tree/compatible", "raspberrypi,"))
             platform_type = MRAA_RASPBERRY_PI;
     }

--- a/src/arm/arm.c
+++ b/src/arm/arm.c
@@ -85,7 +85,9 @@ mraa_arm_platform()
     /* Get compatible string from Device tree for boards that dont have enough info in /proc/cpuinfo
      */
     if (platform_type == MRAA_UNKNOWN_PLATFORM) {
-        if (mraa_file_contains("/proc/device-tree/compatible", "qcom,apq8016-sbc"))
+        if (mraa_file_contains("/proc/device-tree/model", "s900"))
+            platform_type = MRAA_96BOARDS;
+        else if (mraa_file_contains("/proc/device-tree/compatible", "qcom,apq8016-sbc"))
             platform_type = MRAA_96BOARDS;
         else if (mraa_file_contains("/proc/device-tree/compatible", "arrow,apq8096-db820c"))
             platform_type = MRAA_96BOARDS;
@@ -95,8 +97,6 @@ mraa_arm_platform()
         else if (mraa_file_contains("/proc/device-tree/model", "HiKey960"))
             platform_type = MRAA_96BOARDS;
         else if (mraa_file_contains("/proc/device-tree/model", "ROCK960"))
-            platform_type = MRAA_96BOARDS;
-        else if (mraa_file_contains("/proc/device-tree/model", "s900"))
             platform_type = MRAA_96BOARDS;
         else if (mraa_file_contains("/proc/device-tree/compatible", "raspberrypi,"))
             platform_type = MRAA_RASPBERRY_PI;


### PR DESCRIPTION
This PR adds Ultra96 board support, one of the Consumer Edition boards of the 96Boards family.

Ultra96 is an Arm-based, Xilinx Zynq UltraScale+ MPSoC development board. This board runs petalinux distribution on the ARM core and integrates Xilinx programmable logic (PL) UltraScale architecture in a single fabric.

This PR also has a commit which cleans-up the 96Boards.c file by sorting the board support in alphabetical order and running clang-format.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>