### PR TITLE
ioinit: Update to build/test C++ ioinit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8.11)
 project (mraa C CXX)
 
 FIND_PACKAGE (Threads REQUIRED)
@@ -73,6 +73,17 @@ foreach (flag ${MRAA_BOTH_WARNING_FLAGS} ${MRAA_CXX_WARNING_FLAGS})
     message (WARNING "C++ compiler does not support flag \"${flag}\"")
   endif ()
 endforeach ()
+
+# This function adds the c++11 flag to a c++ target (if supported)
+function(use_cxx_11 targetname)
+  include(CheckCXXCompilerFlag)
+  CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+  if (COMPILER_SUPPORTS_CXX11)
+    set_target_properties(${targetname} PROPERTIES COMPILE_FLAGS "-std=c++11")
+  else()
+    message(FATAL_ERROR "Target '${targetname}' requires c++11 which is not supported by this compiler")
+  endif()
+endfunction()
 
 # Set CMAKE_INSTALL_LIBDIR if not defined
 include(GNUInstallDirs)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Use the IN_LIST operator if available (for gtest)
+if(POLICY CMP0057)
+    cmake_policy(SET CMP0057 NEW)
+endif()
+
 # For now, Google Test is NOT required */
 find_package(GTest)
 
@@ -9,37 +14,46 @@ endif()
 
 # Unit tests - C common header methods
 add_executable(test_unit_common_h api/api_common_h_unit.cxx)
-target_link_libraries(test_unit_common_h GTest::GTest GTest::Main mraa)
+target_link_libraries(test_unit_common_h ${GTEST_BOTH_LIBRARIES} mraa)
 target_include_directories(test_unit_common_h
     PRIVATE "${CMAKE_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}/api" "${CMAKE_SOURCE_DIR}/api/mraa")
-gtest_add_tests(test_unit_common_h "" AUTO)
+gtest_add_tests(test_unit_common_h "" api/api_common_h_unit.cxx)
 list(APPEND GTEST_UNIT_TEST_TARGETS test_unit_common_h)
 
 # Unit tests - C++ common header methods
 add_executable(test_unit_common_hpp api/api_common_hpp_unit.cxx)
-target_link_libraries(test_unit_common_hpp GTest::GTest GTest::Main mraa)
+target_link_libraries(test_unit_common_hpp ${GTEST_BOTH_LIBRARIES} mraa)
 target_include_directories(test_unit_common_hpp PRIVATE "${CMAKE_SOURCE_DIR}/api")
-gtest_add_tests(test_unit_common_hpp "" AUTO)
+gtest_add_tests(test_unit_common_hpp "" api/api_common_hpp_unit.cxx)
 list(APPEND GTEST_UNIT_TEST_TARGETS test_unit_common_hpp)
 
 if (FTDI4222 AND USBPLAT)
     # Unit tests - Test platform extenders (as much as possible)
     add_executable(test_unit_ftdi4222 platform_extender/platform_extender.cxx)
-    target_link_libraries(test_unit_ftdi4222 GTest::GTest GTest::Main mraa-platform-ft4222 dl)
+    target_link_libraries(test_unit_ftdi4222 ${GTEST_BOTH_LIBRARIES} mraa-platform-ft4222 dl)
     target_include_directories(test_unit_ftdi4222 PRIVATE "${PROJECT_SOURCE_DIR}/api"
         "${PROJECT_SOURCE_DIR}/api/mraa"
         "${PROJECT_SOURCE_DIR}/include")
-    gtest_add_tests(test_unit_ftdi4222 "" AUTO)
+    gtest_add_tests(test_unit_ftdi4222 "" platform_extender/platform_extender.cxx)
     list(APPEND GTEST_UNIT_TEST_TARGETS test_unit_ftdi4222)
 endif ()
 
 # Unit tests - test C initio header methods on MOCK platform only
 if (DETECTED_ARCH STREQUAL "MOCK")
     add_executable(test_unit_ioinit_h api/mraa_initio_h_unit.cxx)
-    target_link_libraries(test_unit_ioinit_h GTest::GTest GTest::Main mraa)
+    target_link_libraries(test_unit_ioinit_h ${GTEST_BOTH_LIBRARIES} mraa)
     target_include_directories(test_unit_ioinit_h PRIVATE "${CMAKE_SOURCE_DIR}/api")
-    gtest_add_tests(test_unit_ioinit_h "" AUTO)
+    gtest_add_tests(test_unit_ioinit_h "" api/mraa_initio_h_unit.cxx)
     list(APPEND GTEST_UNIT_TEST_TARGETS test_unit_ioinit_h)
+
+    add_executable(test_unit_ioinit_hpp api/mraa_initio_hpp_unit.cxx)
+    target_link_libraries(test_unit_ioinit_hpp ${GTEST_BOTH_LIBRARIES} mraa)
+    target_include_directories(test_unit_ioinit_hpp PRIVATE "${CMAKE_SOURCE_DIR}/api")
+    gtest_add_tests(test_unit_ioinit_hpp "" api/mraa_initio_hpp_unit.cxx)
+    list(APPEND GTEST_UNIT_TEST_TARGETS test_unit_ioinit_hpp)
+
+    # The initio C++ header requires c++11
+    use_cxx_11(test_unit_ioinit_hpp)
 endif()
 
 # Add a target for all unit tests

--- a/tests/unit/api/mraa_initio_hpp_unit.cxx
+++ b/tests/unit/api/mraa_initio_hpp_unit.cxx
@@ -1,0 +1,170 @@
+/*
+ * Author: Mihai Stefanescu <mihai.stefanescu@rinftech.com>
+ * Copyright (c) 2018 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "mraa/initio.hpp"
+#include "gtest/gtest.h"
+#include <iostream>
+#include <exception>
+
+
+/* MRAA IO INIT hpp test fixture */
+class mraa_initio_hpp_unit : public ::testing::Test
+{
+};
+
+/* Test for an invalid AIO init. */
+TEST_F(mraa_initio_hpp_unit, test_aio_init_invalid)
+{
+    ASSERT_THROW(mraa::MraaIo io("a:bogus:10"), std::runtime_error);
+}
+
+/* Test for a valid AIO init. */
+TEST_F(mraa_initio_hpp_unit, test_aio_init_valid)
+{
+    mraa::MraaIo io("a:0:10");
+    ASSERT_EQ(1, io.aios.size());
+}
+
+///* Test for an invalid GPIO init. */
+//TEST_F(mraa_initio_hpp_unit, test_gpio_init_invalid)
+//{
+//    ASSERT_THROW(mraa::MraaIo io("g:0:34"), std::runtime_error);
+//}
+//
+///* Test for a valid GPIO init. */
+//TEST_F(mraa_initio_hpp_unit, test_gpio_init_valid)
+//{
+//    mraa::MraaIo io("g:0:1");
+//    ASSERT_EQ(1, io.gpios.size());
+//}
+//
+///* Test for a successful I2C init. */
+//TEST_F(mraa_initio_hpp_unit, test_i2c_init)
+//{
+//    mraa_io_descriptor* desc;
+//    mraa_result_t status;
+//
+//    status = mraa_io_init("i:0:16", &desc);
+//    ASSERT_EQ(status, MRAA_SUCCESS);
+//
+//    status = mraa_io_close(desc);
+//    ASSERT_EQ(status, MRAA_SUCCESS);
+//}
+//
+///* Test for a successful IIO init. */
+//TEST_F(mraa_initio_hpp_unit, test_iio_init)
+//{
+//    /*mraa_io_descriptor* desc;
+//     mraa_result_t status;
+//
+//     status = mraa_io_init("ii:0x1", &desc);
+//     ASSERT_EQ(status, MRAA_SUCCESS);
+//
+//     status = mraa_io_close(desc);
+//     ASSERT_EQ(status, MRAA_SUCCESS);*/
+//}
+//
+///* Test for a successful PWM init. */
+//TEST_F(mraa_initio_hpp_unit, test_pwm_init)
+//{
+//    /*mraa_io_descriptor* desc;
+//     mraa_result_t status;
+//
+//     status = mraa_io_init("p:1", &desc);
+//     ASSERT_EQ(status, MRAA_SUCCESS);
+//
+//     status = mraa_io_close(desc);
+//     ASSERT_EQ(status, MRAA_SUCCESS);*/
+//}
+//
+///* Test for a successful SPI init. */
+//TEST_F(mraa_initio_hpp_unit, test_spi_init)
+//{
+//    mraa_io_descriptor* desc;
+//    mraa_result_t status;
+//
+//    status = mraa_io_init("s:0x0:mode2:400000", &desc);
+//    ASSERT_EQ(status, MRAA_SUCCESS);
+//
+//    status = mraa_io_close(desc);
+//    ASSERT_EQ(status, MRAA_SUCCESS);
+//}
+//
+///* Test for a successful UART init. */
+//TEST_F(mraa_initio_hpp_unit, test_uart_init)
+//{
+//    mraa_io_descriptor* desc;
+//    mraa_result_t status;
+//
+//    status = mraa_io_init("u:0x0:9600:8N1", &desc);
+//    ASSERT_EQ(status, MRAA_SUCCESS);
+//
+//    status = mraa_io_close(desc);
+//    ASSERT_EQ(status, MRAA_SUCCESS);
+//}
+//
+///* Test for a successful UART_OW init. */
+//TEST_F(mraa_initio_hpp_unit, test_uart_ow_init)
+//{
+//    /*mraa_io_descriptor* desc;
+//     mraa_result_t status;
+//
+//     status = mraa_io_init("ow:0x1", &desc);
+//     ASSERT_EQ(status, MRAA_SUCCESS);
+//
+//     status = mraa_io_close(desc);
+//     ASSERT_EQ(status, MRAA_SUCCESS);*/
+//}
+//
+///* Test for multiple IO initialization and access the structs for
+//   read/write operations. */
+//TEST_F(mraa_initio_hpp_unit, test_multiple_init)
+//{
+//    /*mraa_io_descriptor* desc;
+//    mraa_result_t status;
+//
+//    status = mraa_io_init("g:13:out:1,g:11:out:1", &desc);
+//    ASSERT_EQ(status, MRAA_SUCCESS);
+//
+//    for (int i = 0; i < 2; ++i) {
+//      ASSERT_EQ(mraa_gpio_read(desc->gpios[i]), 1);
+//    }
+//
+//    status = mraa_io_close(desc);
+//    ASSERT_EQ(status, MRAA_SUCCESS);*/
+//}
+//
+//TEST_F(mraa_initio_hpp_unit, test_leftover_string)
+//{
+//    mraa_io_descriptor* desc;
+//    mraa_result_t status;
+//
+//    status = mraa_io_init("a:0:10,any_string", &desc);
+//    ASSERT_EQ(status, MRAA_SUCCESS);
+//
+//    ASSERT_STREQ(desc->leftover_str, "any_string");
+//
+//    status = mraa_io_close(desc);
+//    ASSERT_EQ(status, MRAA_SUCCESS);
+//}


### PR DESCRIPTION
Multiple changes necessary to enable this.  The main goal is to build
and run the C++ ioinit unit tests (which require c++11)

    * Updated mraa required CMake version to 2.8.11 (this is needed for
      the target_xxx_xxx CMake syntax.
    * Added function for adding the c++11 flag give a CMake target.
    * Updated unit tests for range of CMake versions (tested on 2.8.11,
      3.8.2, 3.9.6, and 3.12.0).
    * Added C++ unit test file (more needed here).)

Signed-off-by: Noel Eck <noel.eck@intel.com>