### PR TITLE
mraa: fix mraa_gpio_lookup function

### DIFF
--- a/src/mraa.c
+++ b/src/mraa.c
@@ -917,7 +917,11 @@ mraa_gpio_lookup(const char* pin_name)
         return -1;
     }
 
-    for (i = 0; i < plat->gpio_count; i++) {
+    for (i = 0; i < plat->phy_pin_count; i++) {
+         // Skip non GPIO pins
+         if (!(plat->pins[i].capabilities.gpio))
+             continue;
+
          if (plat->pins[i].name != NULL &&
              strncmp(pin_name, plat->pins[i].name, strlen(plat->pins[i].name) + 1) == 0) {
              return i;


### PR DESCRIPTION
1. Extend the lookup count to phy_pin_count to cover all physical pins
   exposed on the board
2. Ignore the non GPIO pins by checking for GPIO capability

Tested on: Dragonboard410c
Fixes: #917 

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>