### PR TITLE
Add support for initializing onboard LEDs based on board definition

### DIFF
--- a/api/mraa/led.h
+++ b/api/mraa/led.h
@@ -47,15 +47,23 @@ extern "C" {
 typedef struct _led* mraa_led_context;
 
 /**
+ * Initialise led_context, based on led index.
+ *
+ *  @param led ID of the LED
+ *  @returns LED context or NULL
+ */
+mraa_led_context mraa_led_init(int led);
+
+/**
  * Initialise led_context, based on led function name.
  * The structure of LED entry in sysfs is "devicename:colour:function"
  * This api expects only one unique LED identifier which would be
- * "function" name most often. For instance, `mraa_led_init("user4");`
+ * "function" name most often. For instance, `mraa_led_init_raw("user4");`
  *
- *  @param led Name of the LED
+ *  @param led_dev Name of the LED device
  *  @returns LED context or NULL
  */
-mraa_led_context mraa_led_init(const char* led);
+mraa_led_context mraa_led_init_raw(const char* led_dev);
 
 /**
  * Set LED brightness

--- a/api/mraa/led.hpp
+++ b/api/mraa/led.hpp
@@ -44,11 +44,25 @@ class Led
     /**
      * Instantiates an LED object
      *
-     * @param led LED fuction name to use
+     * @param led LED index to use
      */
-    Led(const char* led)
+    Led(int led)
     {
         m_led = mraa_led_init(led);
+
+        if (m_led == NULL) {
+            throw std::invalid_argument("Invalid LED name specified");
+        }
+    }
+
+    /**
+     * Instantiates an LED object
+     *
+     * @param led_dev LED function name to use
+     */
+    Led(std::string led_dev)
+    {
+        m_led = mraa_led_init_raw(led_dev.c_str());
 
         if (m_led == NULL) {
             throw std::invalid_argument("Invalid LED name specified");

--- a/examples/c/led.c
+++ b/examples/c/led.c
@@ -36,7 +36,7 @@
 #include "mraa/led.h"
 
 /* LED name */
-#define USER_LED "user1"
+#define USER_LED 0
 
 /* trigger type */
 #define LED_TRIGGER "heartbeat"

--- a/include/arm/96boards.h
+++ b/include/arm/96boards.h
@@ -38,6 +38,7 @@ extern "C" {
 #define MRAA_96BOARDS_LS_SPI_COUNT  1
 #define MRAA_96BOARDS_LS_UART_COUNT 2
 #define MRAA_96BOARDS_LS_PIN_COUNT  40
+#define MRAA_96BOARDS_LED_COUNT 6
 
 mraa_board_t* mraa_96boards();
 

--- a/include/mraa_internal_types.h
+++ b/include/mraa_internal_types.h
@@ -46,7 +46,7 @@
 #define MAX_AIO_COUNT 7
 #define MAX_UART_COUNT 6
 #define MAX_PWM_COUNT 6
-
+#define MAX_LED_COUNT 12
 
 // general status failures for internal functions
 #define MRAA_PLATFORM_NO_INIT -3
@@ -455,6 +455,16 @@ typedef struct {
 } mraa_aio_dev_t;
 
 /**
+ * Structure representing an LED device.
+ */
+typedef struct {
+    /*@{*/
+    char *name; /**< LED device function name */
+    unsigned int index; /**< Index as exposed in the platform */
+    /*@}*/
+} mraa_led_dev_t;
+
+/**
  * A Structure representing a platform/board.
  */
 typedef struct _board_t {
@@ -490,6 +500,8 @@ typedef struct _board_t {
     mraa_adv_func_t* adv_func;    /**< Pointer to advanced function disptach table */
     struct _board_t* sub_platform;     /**< Pointer to sub platform */
     mraa_boolean_t chardev_capable;  /**< Decide what interface is being used: old sysfs or new char device*/
+    mraa_led_dev_t led_dev[MAX_LED_COUNT]; /**< Array of LED devices */
+    unsigned int led_dev_count; /**< Total onboard LED device count */
     /*@}*/
 } mraa_board_t;
 

--- a/src/arm/96boards.c
+++ b/src/arm/96boards.c
@@ -64,6 +64,7 @@ int db410c_chardev_map[MRAA_96BOARDS_LS_GPIO_COUNT][2] = {
 };
 
 const char* db410c_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyMSM0", "/dev/ttyMSM1" };
+const char* db410c_led[MRAA_96BOARDS_LED_COUNT] = { "user1", "user2", "user3", "user4", "bt", "wlan" };
 
 // Dragonboard820c
 int db820c_ls_gpio_pins[MRAA_96BOARDS_LS_GPIO_COUNT] = {
@@ -269,6 +270,13 @@ mraa_96boards()
             chardev_map = &db410c_chardev_map;
             b->uart_dev[0].device_path = (char*) db410c_serialdev[0];
             b->uart_dev[1].device_path = (char*) db410c_serialdev[1];
+            b->led_dev[0].name = (char*) db410c_led[0];
+            b->led_dev[1].name = (char*) db410c_led[1];
+            b->led_dev[2].name = (char*) db410c_led[2];
+            b->led_dev[3].name = (char*) db410c_led[3];
+            b->led_dev[4].name = (char*) db410c_led[4];
+            b->led_dev[5].name = (char*) db410c_led[5];
+            b->led_dev_count = MRAA_96BOARDS_LED_COUNT;
             b->adv_func->gpio_mmap_setup = &mraa_db410c_mmap_setup;
             b->chardev_capable = 1;
         } else if (mraa_file_contains(DT_BASE "/model", "Qualcomm Technologies, Inc. DB820c")) {


### PR DESCRIPTION
This patchset adds support for initializing onboard LEDs based on board definition. LED board definition has been added for 96Boards Dragonboard410c with 6 LEDs as an example.

For initializing LEDs based on the function name, a new API `mraa_led_init_raw` has been introduced. To accompany this change, `c` example is modified to pass LED index instead of name. C++, Python examples need not be modified since they have been mapped to `mraa_led_init_raw` API.