### PR TITLE
Ultra96: Add support for Avnet Ultra96 board

### DIFF
--- a/src/arm/96boards.c
+++ b/src/arm/96boards.c
@@ -64,7 +64,8 @@ int db410c_chardev_map[MRAA_96BOARDS_LS_GPIO_COUNT][2] = {
 };
 
 const char* db410c_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyMSM0", "/dev/ttyMSM1" };
-const char* db410c_led[MRAA_96BOARDS_LED_COUNT] = { "user1", "user2", "user3", "user4", "bt", "wlan" };
+const char* db410c_led[MRAA_96BOARDS_LED_COUNT] = { "user1", "user2", "user3", "user4", "bt", "wla"
+                                                                                              "n" };
 
 // Dragonboard820c
 int db820c_ls_gpio_pins[MRAA_96BOARDS_LS_GPIO_COUNT] = {
@@ -99,9 +100,8 @@ int hikey960_chardev_map[MRAA_96BOARDS_LS_GPIO_COUNT][2] = {
 const char* hikey960_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyAMA3", "/dev/ttyAMA6" };
 
 // Rock960
-int rock960_ls_gpio_pins[MRAA_96BOARDS_LS_GPIO_COUNT] = { 
-    1006, 1002, 1041, 1042, 1121, 1128, 1124, 1131, 1125, 1132, 1050, 1055 
-};
+int rock960_ls_gpio_pins[MRAA_96BOARDS_LS_GPIO_COUNT] = { 1006, 1002, 1041, 1042, 1121, 1128,
+                                                          1124, 1131, 1125, 1132, 1050, 1055 };
 
 const char* rock960_serialdev[MRAA_96BOARDS_LS_UART_COUNT] = { "/dev/ttyS3", "/dev/ttyS4" };
 
@@ -304,7 +304,8 @@ mraa_96boards()
             ls_gpio_pins = rock960_ls_gpio_pins;
             b->uart_dev[0].device_path = (char*) rock960_serialdev[0];
             b->uart_dev[1].device_path = (char*) rock960_serialdev[1];
-        } else if (mraa_file_contains(DT_BASE "/model", "ZynqMP ZCU100 RevC")) {
+        } else if ((mraa_file_contains(DT_BASE "/model", "ZynqMP ZCU100 RevC")) ||
+                   (mraa_file_contains(DT_BASE "/model", "Avnet Ultra96 Rev1"))) {
             b->platform_name = PLATFORM_NAME_ULTRA96;
             chardev_map = &ultra96_chardev_map;
             b->uart_dev[0].device_path = (char*) ultra96_serialdev[0];

--- a/src/arm/arm.c
+++ b/src/arm/arm.c
@@ -100,6 +100,8 @@ mraa_arm_platform()
             platform_type = MRAA_96BOARDS;
         else if (mraa_file_contains("/proc/device-tree/model", "ZynqMP ZCU100 RevC"))
             platform_type = MRAA_96BOARDS;
+        else if (mraa_file_contains("/proc/device-tree/model", "Avnet Ultra96 Rev1"))
+            platform_type = MRAA_96BOARDS;
         else if (mraa_file_contains("/proc/device-tree/compatible", "raspberrypi,"))
             platform_type = MRAA_RASPBERRY_PI;
     }


### PR DESCRIPTION
Add support for Ultra96 board: Ultra96 is an Arm-based, Xilinx Zynq
UltraScale+ MPSoC development board based on the Linaro 96Boards
Consumer Edition specification.

Signed-off-by: Michal Simek <michal.simek@xilinx.com>
Signed-off-by: Peter Ryser <peter.ryser@xilinx.com>
Signed-off-by: Manjukumar Matha <manjukumar.harthikote-matha@xilinx.com>
Signed-off-by: Sai Hari Chandana Kalluri <chandana.kalluri@xilinx.com>