### PR TITLE
BeagleBone: Fix detection of emmc and PCM for mraa pins 74-77

### DIFF
--- a/src/arm/beaglebone.c
+++ b/src/arm/beaglebone.c
@@ -370,6 +370,7 @@ mraa_beaglebone()
 {
     unsigned int emmc_enabled = 1;
     unsigned int hdmi_enabled = 1;
+    unsigned int pcm0_enabled = 1;
     unsigned int i2c0_enabled = 1;
     unsigned int i2c1_enabled = 1;
     unsigned int spi0_enabled = 0;
@@ -408,6 +409,11 @@ mraa_beaglebone()
         hdmi_enabled = 1;
     else
         hdmi_enabled = 0;
+
+    if (mraa_file_exist("/sys/class/sound/pcmC0D0p"))
+        pcm0_enabled = 1;
+    else
+        pcm0_enabled = 0;
 
     if (mraa_file_exist("/sys/class/i2c-dev/i2c-0"))
         i2c0_enabled = 1;
@@ -1256,7 +1262,7 @@ mraa_beaglebone()
     b->pins[BUILD_PIN(P9, 27)].gpio.parent_id = 0;
     b->pins[BUILD_PIN(P9, 27)].gpio.mux_total = 0;
 
-    if (emmc_enabled != 1) {
+    if (pcm0_enabled != 1) {
         if (spi1_enabled == 1) {
             strncpy(b->pins[BUILD_PIN(P9, 28)].name, "SPI1CS0", MRAA_PIN_NAME_SIZE);
             b->pins[BUILD_PIN(P9, 28)].capabilities =
@@ -1275,7 +1281,7 @@ mraa_beaglebone()
     b->pins[BUILD_PIN(P9, 28)].gpio.mux_total = 0;
     b->pins[BUILD_PIN(P9, 28)].spi.mux_total = 0;
 
-    if (emmc_enabled != 1) {
+    if (pcm0_enabled != 1) {
         if (spi1_enabled == 1) {
             strncpy(b->pins[BUILD_PIN(P9, 29)].name, "SPI1D0", MRAA_PIN_NAME_SIZE);
             b->pins[BUILD_PIN(P9, 29)].capabilities =
@@ -1294,7 +1300,7 @@ mraa_beaglebone()
     b->pins[BUILD_PIN(P9, 29)].gpio.mux_total = 0;
     b->pins[BUILD_PIN(P9, 29)].spi.mux_total = 0;
 
-    if (emmc_enabled != 1) {
+    if (pcm0_enabled != 1) {
         if (spi1_enabled == 1) {
             strncpy(b->pins[BUILD_PIN(P9, 30)].name, "SPI1D1", MRAA_PIN_NAME_SIZE);
             b->pins[BUILD_PIN(P9, 30)].capabilities =
@@ -1313,7 +1319,7 @@ mraa_beaglebone()
     b->pins[BUILD_PIN(P9, 30)].gpio.mux_total = 0;
     b->pins[BUILD_PIN(P9, 30)].spi.mux_total = 0;
 
-    if (emmc_enabled != 1) {
+    if (pcm0_enabled != 1) {
         if (spi1_enabled == 1) {
             strncpy(b->pins[BUILD_PIN(P9, 31)].name, "SPI1CLK", MRAA_PIN_NAME_SIZE);
             b->pins[BUILD_PIN(P9, 31)].capabilities =


### PR DESCRIPTION
This is a fix for the beaglebone.c code that makes it so it can be run without the SD card on the BBG & BBB and use pins 74-77 as GPIO/SPI.  Several people have asked me for this code.  I thought it might be nice to share with the rest of the  group.

This fixes the problem of detecting if pins 74-77 are available for gpio/spi use.  These pins were sown to be used by the emmc, but actually used by the sound pcm.  If the sound PCM is disabled and the emmc is enabled the pinse can now be used.  mraa-gpio list output Pins 74-77
73     GPIO115: GPIO
74     GPIO113: GPIO SPI
75     GPIO111: GPIO SPI
76     GPIO112: GPIO SPI
77     GPIO110: GPIO SPI

to build:
1. clone repo
2. sudo apt-get install build-essential python-dev cmake automake libpcre3 libpcre3-dev byacc flex swig3.0
3. cd mraa, mkdir build, cd build
4. cmake -D CMAKE_INSTALL_PREFIX=/usr ..
5. make
6. sudo make install

This has been verified to work on BBGW, and BBBW with 9.0-9.5 with emmc enabled and PCM aduio turned off.  It is so nice to have control of these pins when running with out an SD card.

Signed-off-by: ChuckDuey <cduey@msn.com>