### PR TITLE
gpio: Introduce mraa_gpio_init_by_name API

### DIFF
--- a/api/mraa/gpio.h
+++ b/api/mraa/gpio.h
@@ -125,6 +125,14 @@ typedef mraa_gpio_event* mraa_gpio_events_t;
 mraa_gpio_context mraa_gpio_init(int pin);
 
 /**
+ * Initialise gpio_context, based on gpio line name
+ *
+ *  @param name GPIO line name, i.e GPIO-A
+ *  @returns gpio context or NULL
+ */
+mraa_gpio_context mraa_gpio_init_by_name(char* name);
+
+/**
  * Initialise gpio_context, based on board number, for multiple pins (can be one).
  *
  *  @param pins Pin array read from the board

--- a/include/gpio/gpio_chardev.h
+++ b/include/gpio/gpio_chardev.h
@@ -64,6 +64,7 @@ mraa_boolean_t mraa_is_gpio_line_open_drain(mraa_gpiod_line_info *linfo);
 mraa_boolean_t mraa_is_gpio_line_open_source(mraa_gpiod_line_info *linfo);
 
 int mraa_get_number_of_gpio_chips();
+int mraa_get_chip_infos(mraa_gpiod_chip_info*** cinfos);
 
 /* Multiple gpio support. */
 typedef struct _gpio_group* mraa_gpiod_group_t;

--- a/include/mraa_internal_types.h
+++ b/include/mraa_internal_types.h
@@ -174,6 +174,11 @@ struct _gpio {
         ++k) \
             if (dev->gpio_group[k].is_required)
 
+#define for_each_gpio_chip(cinfo, cinfos, num_chips) \
+    for (int idx = 0; \
+        idx < num_chips && (cinfo = cinfos[idx]); \
+        (idx++))
+
 /**
  * A structure representing a I2C bus
  */

--- a/src/gpio/gpio_chardev.c
+++ b/src/gpio/gpio_chardev.c
@@ -22,9 +22,9 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include "gpio/gpio_chardev.h"
 #include "linux/gpio.h"
 #include "mraa_internal.h"
-#include "gpio/gpio_chardev.h"
 
 #include <dirent.h>
 #include <errno.h>
@@ -52,7 +52,8 @@ _mraa_free_gpio_groups(mraa_gpio_context dev)
 {
     mraa_gpiod_group_t gpio_iter;
 
-    for_each_gpio_group(gpio_iter, dev) {
+    for_each_gpio_group(gpio_iter, dev)
+    {
         if (gpio_iter->gpio_lines) {
             free(gpio_iter->gpio_lines);
         }
@@ -105,7 +106,8 @@ _mraa_close_gpio_event_handles(mraa_gpio_context dev)
 {
     mraa_gpiod_group_t gpio_iter;
 
-    for_each_gpio_group(gpio_iter, dev) {
+    for_each_gpio_group(gpio_iter, dev)
+    {
         if (gpio_iter->event_handles != NULL) {
             for (int j = 0; j < gpio_iter->num_gpio_lines; ++j) {
                 close(gpio_iter->event_handles[j]);
@@ -124,7 +126,8 @@ _mraa_close_gpio_desc(mraa_gpio_context dev)
 {
     mraa_gpiod_group_t gpio_iter;
 
-    for_each_gpio_group(gpio_iter, dev) {
+    for_each_gpio_group(gpio_iter, dev)
+    {
         if (gpio_iter->gpiod_handle != -1) {
             close(gpio_iter->gpiod_handle);
             gpio_iter->gpiod_handle = -1;
@@ -376,56 +379,85 @@ mraa_get_line_values(int line_handle, unsigned int num_lines, unsigned char outp
 
 
 mraa_boolean_t
-mraa_is_gpio_line_kernel_owned(mraa_gpiod_line_info *linfo)
+mraa_is_gpio_line_kernel_owned(mraa_gpiod_line_info* linfo)
 {
     return (linfo->flags & GPIOLINE_FLAG_KERNEL);
 }
 
 mraa_boolean_t
-mraa_is_gpio_line_dir_out(mraa_gpiod_line_info *linfo)
+mraa_is_gpio_line_dir_out(mraa_gpiod_line_info* linfo)
 {
     return (linfo->flags & GPIOLINE_FLAG_IS_OUT);
 }
 
 mraa_boolean_t
-mraa_is_gpio_line_active_low(mraa_gpiod_line_info *linfo)
+mraa_is_gpio_line_active_low(mraa_gpiod_line_info* linfo)
 {
     return (linfo->flags & GPIOLINE_FLAG_ACTIVE_LOW);
 }
 
 mraa_boolean_t
-mraa_is_gpio_line_open_drain(mraa_gpiod_line_info *linfo)
+mraa_is_gpio_line_open_drain(mraa_gpiod_line_info* linfo)
 {
     return (linfo->flags & GPIOLINE_FLAG_OPEN_DRAIN);
 }
 
 mraa_boolean_t
-mraa_is_gpio_line_open_source(mraa_gpiod_line_info *linfo)
+mraa_is_gpio_line_open_source(mraa_gpiod_line_info* linfo)
 {
     return (linfo->flags & GPIOLINE_FLAG_OPEN_SOURCE);
+}
+
+static int
+dir_filter(const struct dirent* dir)
+{
+    return !strncmp(dir->d_name, CHIP_DEV_PREFIX, strlen(CHIP_DEV_PREFIX));
 }
 
 int
 mraa_get_number_of_gpio_chips()
 {
-    int num_chips = 0;
-    DIR* dev_dir;
-    struct dirent* dir;
-    const unsigned int len = strlen(CHIP_DEV_PREFIX);
+    int num_chips;
+    struct dirent** dirs;
 
-    dev_dir = opendir(DEV_DIR);
-    if (dev_dir) {
-        while ((dir = readdir(dev_dir)) != NULL) {
-            if (!strncmp(dir->d_name, CHIP_DEV_PREFIX, len)) {
-                num_chips++;
-            }
-        }
-        closedir(dev_dir);
-    } else {
-        syslog(LOG_ERR, "[GPIOD_INTERFACE]: opendir() error");
+    num_chips = scandir("/dev", &dirs, dir_filter, alphasort);
+    if (num_chips < 0) {
+        syslog(LOG_ERR, "[GPIOD_INTERFACE]: scandir() error");
         return -1;
     }
 
-    /* Assume opendir() error. */
+    return num_chips;
+}
+
+int
+mraa_get_chip_infos(mraa_gpiod_chip_info*** cinfos)
+{
+    int num_chips, i;
+    struct dirent** dirs;
+    mraa_gpiod_chip_info** cinfo;
+
+    num_chips = scandir("/dev", &dirs, dir_filter, alphasort);
+    if (num_chips < 0) {
+        syslog(LOG_ERR, "[GPIOD_INTERFACE]: scandir() error");
+        return -1;
+    }
+
+    cinfo = (mraa_gpiod_chip_info**) calloc(num_chips, sizeof(mraa_gpiod_chip_info*));
+    if (!cinfo) {
+        syslog(LOG_ERR, "[GPIOD_INTERFACE]: Failed to allocate memory for chip info");
+        return -1;
+    }
+
+    /* Get chip info for all gpiochips present in the platform */
+    for (i = 0; i < num_chips; i++) {
+        cinfo[i] = mraa_get_chip_info_by_name(dirs[i]->d_name);
+        if (!cinfo[i]) {
+            syslog(LOG_ERR, "[GPIOD_INTERFACE]: invalid chip %s", dirs[i]->d_name);
+            return 0;
+        }
+    }
+
+    *cinfos = cinfo;
+
     return num_chips;
 }


### PR DESCRIPTION
This commit introduces mraa_gpio_init_by_name API for initializing
a GPIO by its line name provided by the kernel. This feature depends
on the GPIO chardev support and also the line names present in devicetree
or board files. Accessing GPIO using its line name, removes the dependency
from MRAA specific pin mapping and provides a cleaner way to access GPIOs.
This will solve the issue created by an external gpiochip probing before
the SoC's internal gpio controller and thereby making the MRAA pin mapping
wrong.

Currently, this API only supports initializing a single GPIO at a time. Bindings for the
API will come in successive PRs.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>