### PR TITLE
Some basic readme/contribution docs refresh to get the party started

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributing to Eclipse Mraa (libmraa)                   {#contributing}
 ======================
 
-Eclipse Mraa is an opensource project and we are actively looking for people to help
+Eclipse Mraa is an open source project and we are actively looking for people to help
 with:
 
 - Writing platform supports for all types of boards running linux
@@ -16,7 +16,6 @@ issue first so we can avoid disappointments come merging time!
 Basic rules
 -----------
 - Your code must build
-- Commits must have a sign-off line by at least yourself
 - Commits must be named <file/module>: Some decent description
 - Try not to break master. In any commit.
 - Try to split commits up logically, you will be asked to rebase them if they
@@ -28,13 +27,13 @@ Coding Style
 ------------
 
 Coding style for all code is defined by clang-format, have a look at it. Avoid
-styling fixes as they make history difficult to read. Javascript & Java can
+styling fixes as they make history difficult to read. JavaScript & Java can
 also be parsed through the clang-format, it complains but seems to do an ok
 job. Few exceptions to coding styles:
-- All python code is indented by 2 spaces
-- CmakeLists files are 2 space indented and a space is required before all
-  brackets so endif () and if () and command (). Also use lowercase for
-  everything but variables. Cmake is case insensitive but this isn't the wild
+- All Python code is indented by 2 spaces
+- CMakeLists files are 2 space indented and a space is required before all
+  brackets so `endif ()` and `if ()` and `command ()`. Also use lowercase for
+  everything but variables. CMake is case insensitive but this isn't the wild
   wild west ;-)
 
 Use common sense and don't be afraid to challenge something if it doesn't make sense!
@@ -43,7 +42,7 @@ Author Rules
 ------------
 
 If you create a file, then add yourself as the Author at the top. If you did a
-large contribution to it (or if you want to ;-)), then fee free to add yourself
+large contribution to it (or if you want to ;-)), then feel free to add yourself
 to the contributors list in that file. You can also add your own copyright
 statement to the file but cannot add a license of your own. If you're borrowing
 code that comes from a project with another license, make sure to explicitly
@@ -52,25 +51,23 @@ note this in your PR.
 Eclipse Contributor Agreement
 ------------
 
-Your contribution cannot be accepted unless you have a signed [ECA - Eclipse Foundation Contributor Agreement](http://www.eclipse.org/legal/ECA.php) in place.
+Your contribution cannot be accepted unless you have a signed [ECA - Eclipse Foundation Contributor Agreement](https://www.eclipse.org/legal/eca/) in place.
 
 Here is the checklist for contributions to be _acceptable_:
 
-1. [Create an account at Eclipse](https://dev.eclipse.org/site_login/createaccount.php).
+1. [Create an account at Eclipse](https://accounts.eclipse.org/user/register).
 2. Add your GitHub user name in your account settings.
-3. [Log into the project's portal](https://projects.eclipse.org/) and sign the ["Eclipse ECA"](https://projects.eclipse.org/user/sign/cla).
-4. Ensure that you [_sign-off_](https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#Signing_off_on_a_commit) your Git commits.
+3. [Log in to the projects forge](https://www.eclipse.org/contribute/cla/) and sign the ["Eclipse ECA"](https://accounts.eclipse.org/user/eca).
 5. Ensure that you use the _same_ email address as your Eclipse account in commits.
 6. Include the appropriate copyright notice and license at the top of each file.
 
-Your signing of the ECA will be verified by a webservice called 'ip-validation'
-that checks the email address that signed-off on your commits has signed the
+Your signing of the ECA will be verified by a Github Check called 'eclipsefdn/eca'
+that checks the email address that authored your commits has signed the
 ECA. **Note**: This service is case-sensitive, so ensure the email that signed
-the ECA and that signed-off on your commits is the same, down to the case.
+the ECA and that authored your commits is the same, down to the case.
 
 Where to find us
 ----------------
 
 Hop onto the freenode network on IRC and join #mraa. Please be patient as we're
 not always online.
-

--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
 <p align="center">
-  <img src="http://iotdk.intel.com/misc/logos/mraa.png" height="150px" width="auto" algt="Mraa Logo"/>
+  <img src="http://iotdk.intel.com/misc/logos/mraa.png" height="150px" width="auto" algt="MRAA Logo"/>
 </p>
 
-Eclipse Mraa - Low Level I/O Communications Library for GNU/Linux platforms
+Eclipse MRAA - Low Level I/O Communications Library for GNU/Linux Platforms
 ===========================================================================
 
-Eclipse Mraa (Libmraa) is a C/C++ library with bindings to Java, Python and JavaScript
+Eclipse MRAA (Libmraa) is a C/C++ library with bindings to Java, Python and JavaScript
 to interface with the I/O pins and buses on various IoT and Edge platforms, with a
 structured and sane API where port names/numbering match the board that you are on.
-Use of libmraa does not tie you to specific hardware. Since board detection done at
+Use of libmraa does not tie you to specific hardware. Since board detection is done at
 runtime you can create portable code that will work across the supported platforms.
 
 The intent is to make it easier for developers and sensor manufacturers to map
 their sensors & actuators on top of supported hardware and to allow control of
 low level communication protocol by high level languages & constructs.
 
-The MRAA project is an Eclipse IoT project. A detailed project description can be found [here](https://projects.eclipse.org/proposals/eclipse-mraa).
-
-[![Build Status](https://travis-ci.org/intel-iot-devkit/mraa.svg?branch=master)](https://travis-ci.org/intel-iot-devkit/mraa) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=mraa-master&metric=alert_status)](https://sonarcloud.io/dashboard?id=mraa-master)
+The MRAA project is an Eclipse IoT project. A detailed project description can be found [here](https://projects.eclipse.org/projects/iot.mraa).
 
 Supported Boards
 ================
@@ -87,7 +85,7 @@ RISC-V
 ----
 * [VisionFive](../master/docs/visionfive.md)
 
-Installing on your board
+Installing on Your Board
 ========================
 
 Installing on Ubuntu
@@ -134,22 +132,11 @@ sudo zypper in mraa
 A full list of packages and instructions for installing MRAA for various openSUSE releases
 can be found [here](https://software.opensuse.org/package/mraa).
 
-Install on Fedora Linux
------------------------
-
-There is an mraa package in the main Fedora repository so it can be dnf installed
-in all recent Fedora releases. The Node.js and Python 3 bindings are packaged as
-separate packages.
-
-```bash
-sudo dnf install mraa nodejs-mraa python3-mraa
-```
-
-Installing for Red Hat Enterprise Linux, CentOS and Other Linux Distributions
+Installing on Other Linux Distributions
 ---------------------------
 
-The MRAA project does not currently distribute official binaries for RHEL
-or CentOS so developers will have to compile the project from sources as
+The MRAA project does not currently distribute official binaries for other distributions
+so developers will have to compile the project from sources as
 described in the next section.
 
 For testing and development purposes it may be possible to share and install
@@ -175,6 +162,10 @@ glance at our [debugging](../master/docs/debugging.md) page too.
 
 API Documentation
 =================
+
+**UNDER CONSTRUCTION:** we are working on re-hosting our documentation, so below
+links don't work. Please use the sources and Markdown files under [docs](docs/)
+in the meanwhile.
 
 <a href="http://c.mraa.io"><img src="http://iotdk.intel.com/misc/logos/c++.png"/></a>
 <a href="http://java.mraa.io"><img src="http://iotdk.intel.com/misc/logos/java.png"/></a>


### PR DESCRIPTION
As it says on the tin, this is a basic update to get the overhaul/refresh started. A few opens I'm happy to discuss and correct before we merge:

1. Eclipse Git rules no longer require sign-offs (https://www.eclipse.org/projects/handbook/#resources-commit), so I removed that piece. Do we want to keep it anyway?
2. We used IRC/freenode previously. The channel seems to exist, but after all that controversy and years past, do we still want to? Maybe switch to something else like Zulip, gitter, or whatever else? Drop entirely in favor of Issues + maybe activate Discussions in the repo?
3. Fedora no longer has the mraa package, so removed. I think we can revive that one later after we refresh the project, to increase the chances for them to accept the package anew.
4. Other than that, some link updates, spelling/styling fixes, and MRAA spelling aligned with the Eclipse project page (there are more places, but I want to stage this to avoid styling-only commits, just as our contribution guide suggests).

Closes #1137.