### PR TITLE
Add security policy and legal notices per the EMO review suggestion

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,29 @@
+# Notices for Eclipse MRAA
+
+This content is produced and maintained by the Eclipse MRAA project.
+
+* Project home: https://projects.eclipse.org/projects/iot.mraa
+
+## Trademarks
+
+Eclipse MRAA is a trademark of the Eclipse Foundation.
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the MIT license which is available at
+https://projects.eclipse.org/license/mit-license-mit.
+
+SPDX-License-Identifier: MIT
+
+## Source Code
+
+The project maintains the following source code repositories:
+
+* https://github.com/eclipse/mraa

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Running MRAA tools or applications on Ubuntu systems requires elevated permissio
 Install on Arch Linux
 ---------------------
 
-There is an AUR package for mraa here: https://aur.archlinux.org/packages/mraa
+There is an AUR package for MRAA here: https://aur.archlinux.org/packages/mraa
 
 Install on openSUSE or SLE
 ---------------------------

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+This Eclipse Foundation Project adheres to the [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/security/policy/).
+
+## How To Report a Vulnerability
+
+If you think you have found a vulnerability in this repository, please report it to us through coordinated disclosure.
+
+**Please do not report security vulnerabilities through public issues, discussions, or change requests.**
+
+Instead, report it using one of the following ways:
+
+* Contact the [Eclipse Foundation Security Team](mailto:security@eclipse-foundation.org) via email
+* Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
+* Report a [vulnerability](https://github.com/eclipse/mraa/security/advisories/new) directly via private vulnerability reporting on GitHub
+
+You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
+
+Please include as much of the information listed below as you can to help us better understand and resolve the issue:
+
+* The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
+* Affected version(s)
+* Impact of the issue, including how an attacker might exploit the issue
+* Step-by-step instructions to reproduce the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Full paths of source file(s) related to the manifestation of the issue
+* Configuration required to reproduce the issue
+* Log files that are related to this issue (if possible)
+* Proof-of-concept or exploit code (if possible)
+
+This information will help us triage your report more quickly.
+
+## Supported Versions
+
+We support the latest released version that can be found in the [Releases section of the repo](https://github.com/eclipse/mraa/releases).


### PR DESCRIPTION
Following the suggestion in the [EMO 2.3.0 release review tracking record](https://gitlab.eclipse.org/eclipsefdn/emo-team/emo/-/issues/1076#note_5323276), adding those two files.

* The security policy is based on the [recommended template](https://github.com/eclipse-csi/security-handbook/blob/main/templates/SECURITY.md)
  * I put only the latest release into the supported versions list - open to other approaches and can change, let me know what you think. Also, using the GH "latest release" link, which returns an empty list now, but assuming we'll create one for 2.3.0 and will use Releases going forward.
* The legal notices file is based on the [suggested template from the Handbook](https://www.eclipse.org/projects/handbook/#legaldoc-notice).

While at it, fixed (in a separate commit) one instance of lowercase spelling of the project name in the README, missed it during the first pass.