### PR TITLE
Add basic build/test workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,0 +1,48 @@
+name: Build and test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  Build_and_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runs_on: ubuntu-latest
+            run_tests: true
+          - arch: arm
+            runs_on: ubuntu-24.04-arm
+            run_tests: true
+          - arch: MOCK
+            runs_on: ubuntu-latest
+            run_tests: true
+    runs-on: ${{ matrix.runs_on }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build build-essential python3-dev libnode-dev swig libjson-c-dev git libgtest-dev
+
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake -G Ninja -DBUILDSWIGNODE=on -DBUILDARCH=${{ matrix.arch }} ../
+          ninja
+
+      - name: Run tests
+        if: matrix.run_tests
+        run: |
+          cd build
+          ninja test

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -51,9 +51,6 @@ if (DETECTED_ARCH STREQUAL "MOCK")
     target_include_directories(test_unit_ioinit_hpp PRIVATE "${CMAKE_SOURCE_DIR}/api")
     gtest_add_tests(test_unit_ioinit_hpp "" api/mraa_initio_hpp_unit.cxx)
     list(APPEND GTEST_UNIT_TEST_TARGETS test_unit_ioinit_hpp)
-
-    # The initio C++ header requires c++11
-    use_cxx_11(test_unit_ioinit_hpp)
 endif()
 
 # Add a target for all unit tests


### PR DESCRIPTION
**NOTE**: Given the number of attacks for the workflows/Actions, I suggest we first set the repository option to require approval from maintainers before running any workflows on PRs, and only after that merge this PR.

This builds off of what @tingleby started in https://github.com/eclipse/mraa/tree/test-gha (so added Tom as co-author for the base commit).

Requires https://github.com/eclipse/mraa/pull/1153 to be merged for Python tests to run.

While at it, fixed a failing GTest compilation due to forced c++11 requirement while it now requires at least c++14.

Tested in my fork (with the CMake fix cherry-picked, so Python tests run), example: https://github.com/alext-mkrs/mraa/actions/runs/20212408310.