### PR TITLE
GH workflows: add license headers and enable for the default branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Alex Tereschenko
+#
+# This program and the accompanying materials are made available under the terms
+# of the MIT license which is available at
+# https://projects.eclipse.org/license/mit-license-mit.
+#
+# SPDX-License-Identifier: MIT
+
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Tom Ingleby, Alex Tereschenko
+#
+# This program and the accompanying materials are made available under the terms
+# of the MIT license which is available at
+# https://projects.eclipse.org/license/mit-license-mit.
+#
+# SPDX-License-Identifier: MIT
+
 name: Build and test
 
 on:

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -10,9 +10,9 @@ name: Build and test
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, master ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, master ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Thanks Tom for merging #1154, I've realized I should have added the license headers too, per the recent EMO discussion.

We also have `master` as the default branch, so add that, without removing `main`, assuming we might want to rename in some future.

Here is a couple of updates.